### PR TITLE
Enhancements

### DIFF
--- a/.spelling.yml
+++ b/.spelling.yml
@@ -68,15 +68,29 @@ documents:
     output: build/dictionary/python.dic
   filters:
   - pyspelling.filters.python:
-      strings: false
-      comments: false
+  - pyspelling.flow_control:
+      allow:
+      - py-comment
+  - pyspelling.filters.context:
+      context_visible_first: true
+      delimiters:
+      # Ignore lint (noqa) and coverage (pragma) as well as shebang (#!)
+      - open: ^(?:(?:noqa|pragma)\b|!)
+        content: .*?
+        close: $
+      # Ignore Python encoding string -*- encoding stuff -*-
+      - open: ^-*-
+        content: .*?
+        close: -*-$
   - pyspelling.filters.context:
       context_visible_first: true
       escapes: \\[\\`~]
       delimiters:
-        - open: (?P<open>`+)
-          content: .*?
-          close: (?P=open)
-        - open: (?s)^(?P<open>\s*~{3,})
-          content: .*?
-          close: ^(?P=open)$
+      # Ignore text between inline back ticks
+      - open: (?P<open>`+)
+        content: .*?
+        close: (?P=open)
+      # Ignore multiline content between fences ~~~ content ~~~
+      - open: (?s)^(?P<open>\s*~{3,})
+        content: .*?
+        close: ^(?P=open)$

--- a/.spelling.yml
+++ b/.spelling.yml
@@ -1,4 +1,6 @@
-documents:
+spellchecker: aspell
+
+matrix:
 - name: mkdocs
   sources:
   - site/**/*.html
@@ -11,7 +13,7 @@ documents:
     wordlists:
     - docs/src/dictionary/en-custom.txt
     output: build/dictionary/mkdocs.dic
-  filters:
+  pipeline:
   - pyspelling.filters.html:
       comments: false
       attributes:
@@ -42,7 +44,7 @@ documents:
     wordlists:
     - docs/src/dictionary/en-custom.txt
     output: build/dictionary/mkdocs.dic
-  filters:
+  pipeline:
   - pyspelling.filters.markdown:
   - pyspelling.filters.html:
       comments: false
@@ -66,7 +68,7 @@ documents:
     wordlists:
     - docs/src/dictionary/en-custom.txt
     output: build/dictionary/python.dic
-  filters:
+  pipeline:
   - pyspelling.filters.python:
   - pyspelling.flow_control:
       allow:

--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -2,6 +2,7 @@ BOM
 BOMs
 BeatifulSoup
 BeautifulSoup
+CSS
 Changelog
 EmojiOne
 GitHub
@@ -19,9 +20,11 @@ Stylesheets
 UTF
 YAML
 backticks
+blockish
 bool
 builtins
 chainable
+charset
 chunking
 could've
 dicts
@@ -45,4 +48,6 @@ sortable
 squidfunk
 subclassing
 sublicense
+whitespace
 wildcard
+wordlist

--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -15,6 +15,7 @@ Parsers
 PyMdown
 PySpelling
 PyYaml's
+Stylesheets
 UTF
 YAML
 backticks

--- a/pyspelling/__init__.py
+++ b/pyspelling/__init__.py
@@ -88,9 +88,10 @@ class SpellChecker(object):
                     text = source.text
                 else:
                     text = source.text.encode(encoding)
-                self.log(text, 3)
+                self.log('', 2)
+                self.log(text, 2)
                 cmd = self.setup_command(encoding, options, personal_dict)
-                self.log(str(cmd), 2)
+                self.log(str(cmd), 3)
 
                 wordlist = util.call_spellchecker(cmd, input_text=text, encoding=encoding)
                 yield util.Results([w for w in sorted(set(wordlist.split('\n'))) if w], source.context, source.category)

--- a/pyspelling/__init__.py
+++ b/pyspelling/__init__.py
@@ -8,6 +8,7 @@ from . import settings
 from . import flow_control
 from . import filters
 from wcmatch import glob
+import warnings
 
 version = __version__.version
 version_info = __version__.version_info
@@ -59,27 +60,27 @@ class SpellChecker(object):
 
         return []
 
-    def _filter_pipeline(self, sources, options, personal_dict, filter_index=1, flow_status=flow_control.ALLOW):
-        """Recursive check spelling filters."""
+    def _pipeline_step(self, sources, options, personal_dict, filter_index=1, flow_status=flow_control.ALLOW):
+        """Recursively run text objects through the pipeline steps."""
 
         for source in sources:
             if source._has_error():
                 yield source
-            elif not source._is_bytes() and filter_index < len(self.filters):
-                f = self.filters[filter_index]
+            elif not source._is_bytes() and filter_index < len(self.pipeline_steps):
+                f = self.pipeline_steps[filter_index]
                 if isinstance(f, flow_control.FlowControl):
                     flow_status = f.adjust_flow(source.category)
-                    if filter_index < len(self.filters):
-                        yield from self._filter_pipeline(
+                    if filter_index < len(self.pipeline_steps):
+                        yield from self._pipeline_step(
                             [source], options, personal_dict, filter_index + 1, flow_status
                         )
                 else:
                     if flow_status == flow_control.ALLOW:
-                        yield from self._filter_pipeline(
+                        yield from self._pipeline_step(
                             f.sfilter(source), options, personal_dict, filter_index + 1
                         )
                     elif flow_status == flow_control.SKIP:
-                        yield from self._filter_pipeline(
+                        yield from self._pipeline_step(
                             [source], options, personal_dict, filter_index + 1
                         )
                     else:
@@ -90,9 +91,9 @@ class SpellChecker(object):
                 yield source
 
     def _spelling_pipeline(self, sources, options, personal_dict):
-        """Check spelling."""
+        """Check spelling pipeline."""
 
-        for source in self._filter_pipeline(sources, options, personal_dict):
+        for source in self._pipeline_step(sources, options, personal_dict):
             if source._has_error():
                 yield util.Results([], source.context, source.category, source.error)
             else:
@@ -121,55 +122,68 @@ class SpellChecker(object):
                 if not os.path.isdir(f):
                     yield plugin._parse(f)
 
-    def setup_spellchecker(self, documents):
+    def setup_spellchecker(self, task):
         """Setup spell checker."""
 
         return {}
 
-    def setup_dictionary(self, documents):
+    def setup_dictionary(self, task):
         """Setup dictionary."""
 
         return None
 
-    def _get_filters(self, documents, default_encoding):
+    def _get_filters(self, task, default_encoding):
         """Get filters."""
 
-        self.filters = []
+        self.pipeline_steps = []
         kwargs = {}
         if default_encoding:
             kwargs["default_encoding"] = default_encoding
-        filter_list = documents.get('filters', [])
-        if not filter_list:
-            filter_list.append('pyspelling.filters.text')
-        for f in filter_list:
+        steps = task.get('pipeline', [])
+        if not steps:
+            steps = task.get('filters', [])
+            warnings.warn(
+                "'filters' key in config is deprecated. 'pipeline' should be used going forward.",
+                category=DeprecationWarning,
+                stacklevel=2
+            )
+        if not steps:
+            steps.append('pyspelling.filters.text')
+        for step in steps:
             # Retrieve module and module options
-            if isinstance(f, dict):
-                name, options = list(f.items())[0]
+            if isinstance(step, dict):
+                name, options = list(step.items())[0]
             else:
-                name = f
+                name = step
                 options = {}
             if options is None:
                 options = {}
 
-            module = self._get_module(name, ('get_plugin', 'get_filter'))
+            module = self._get_module(name)
             if issubclass(module, filters.Filter):
-                self.filters.append(module(options, **kwargs))
+                self.pipeline_steps.append(module(options, **kwargs))
             elif issubclass(module, flow_control.FlowControl):
-                self.filters.append(module(options))
+                self.pipeline_steps.append(module(options))
             else:
                 raise ValueError("'%s' is not a valid plugin!" % name)
 
-    def _get_module(self, module, accessor):
+    def _get_module(self, module):
         """Get module."""
 
         if isinstance(module, str):
             mod = importlib.import_module(module)
-        for name in accessor:
+        for name in ('get_plugin', 'get_filter'):
             attr = getattr(mod, name, None)
             if attr is not None:
                 break
+            if name == 'get_filter':
+                warnings.warn(
+                    "'get_filter' is deprecated. Plugins should use 'get_plugin'.",
+                    category=DeprecationWarning,
+                    stacklevel=2
+                )
         if not attr:
-            raise ValueError("Could not find accessor '%s'!" % accessor)
+            raise ValueError("Could not find the 'get_plugin' function in module '%d'!" % module)
         return attr()
 
     def _to_flags(self, text):
@@ -182,20 +196,20 @@ class SpellChecker(object):
                 flags |= self.GLOB_FLAG_MAP.get(value, 0)
         return flags
 
-    def check(self, documents):
+    def run_task(self, task):
         """Walk source and initiate spell check."""
 
         # Perform spell check
-        self.log('Spell Checking %s...' % documents.get('name', ''), 1)
+        self.log('Spell Checking %s...' % task.get('name', ''), 1)
 
         # Setup filters and variables for the spell check
-        encoding = documents.get('default_encoding', '')
-        options = self.setup_spellchecker(documents)
-        output = self.setup_dictionary(documents)
-        glob_flags = self._to_flags(documents.get('glob_flags', "N|B|G"))
-        self._get_filters(documents, encoding)
+        encoding = task.get('default_encoding', '')
+        options = self.setup_spellchecker(task)
+        output = self.setup_dictionary(task)
+        glob_flags = self._to_flags(task.get('glob_flags', "N|B|G"))
+        self._get_filters(task, encoding)
 
-        for sources in self._walk_src(documents.get('sources', []), glob_flags, self.filters[0]):
+        for sources in self._walk_src(task.get('sources', []), glob_flags, self.pipeline_steps[0]):
             yield from self._spelling_pipeline(sources, options, output)
 
 
@@ -208,15 +222,15 @@ class Aspell(SpellChecker):
         super(Aspell, self).__init__(config, binary, verbose)
         self.binary = binary if binary else 'aspell'
 
-    def setup_spellchecker(self, documents):
+    def setup_spellchecker(self, task):
         """Setup spell checker."""
 
-        return documents.get('aspell', {})
+        return task.get('aspell', {})
 
-    def setup_dictionary(self, documents):
+    def setup_dictionary(self, task):
         """Setup dictionary."""
 
-        dictionary_options = documents.get('dictionary', {})
+        dictionary_options = task.get('dictionary', {})
         output = os.path.abspath(dictionary_options.get('output', self.dict_bin))
         lang = dictionary_options.get('lang', 'en')
         wordlists = dictionary_options.get('wordlists', [])
@@ -229,31 +243,47 @@ class Aspell(SpellChecker):
     def compile_dictionary(self, lang, wordlists, output):
         """Compile user dictionary."""
 
-        output_location = os.path.dirname(output)
-        if not os.path.exists(output_location):
-            os.makedirs(output_location)
-        if os.path.exists(output):
-            os.remove(output)
+        cmd = [
+            self.binary,
+            '--lang', lang,
+            '--encoding=utf-8',
+            'create',
+            'master', output
+        ]
 
-        self.log("Compiling Dictionary...", 1)
-        # Read word lists and create a unique set of words
-        words = set()
-        for wordlist in wordlists:
-            with open(wordlist, 'rb') as src:
-                for word in src.read().split(b'\n'):
-                    words.add(word.replace(b'\r', b''))
+        wordlist = ''
 
-        # Compile wordlist against language
-        util.call(
-            [
-                self.binary,
-                '--lang', lang,
-                '--encoding=utf-8',
-                'create',
-                'master', output
-            ],
-            input_text=b'\n'.join(sorted(words)) + b'\n'
-        )
+        try:
+            output_location = os.path.dirname(output)
+            if not os.path.exists(output_location):
+                os.makedirs(output_location)
+            if os.path.exists(output):
+                os.remove(output)
+
+            self.log("Compiling Dictionary...", 1)
+            # Read word lists and create a unique set of words
+            words = set()
+            for wordlist in wordlists:
+                with open(wordlist, 'rb') as src:
+                    for word in src.read().split(b'\n'):
+                        words.add(word.replace(b'\r', b''))
+
+            # Compile wordlist against language
+            util.call(
+                [
+                    self.binary,
+                    '--lang', lang,
+                    '--encoding=utf-8',
+                    'create',
+                    'master', output
+                ],
+                input_text=b'\n'.join(sorted(words)) + b'\n'
+            )
+        except Exception:
+            self.log(cmd, 0)
+            self.log("Current wordlist: '%s'" % wordlist, 0)
+            self.log("Problem compiling dictionary. Check the binary path and options.", 0)
+            raise
 
     def setup_command(self, encoding, options, personal_dict):
         """Setup the command."""
@@ -308,15 +338,15 @@ class Hunspell(SpellChecker):
         super(Hunspell, self).__init__(config, binary, verbose)
         self.binary = binary if binary else 'hunspell'
 
-    def setup_spellchecker(self, documents):
+    def setup_spellchecker(self, task):
         """Setup spell checker."""
 
-        return documents.get('hunspell', {})
+        return task.get('hunspell', {})
 
-    def setup_dictionary(self, documents):
+    def setup_dictionary(self, task):
         """Setup dictionary."""
 
-        dictionary_options = documents.get('dictionary', {})
+        dictionary_options = task.get('dictionary', {})
         output = os.path.abspath(dictionary_options.get('output', self.dict_bin))
         lang = dictionary_options.get('lang', 'en_US')
         wordlists = dictionary_options.get('wordlists', [])
@@ -328,24 +358,30 @@ class Hunspell(SpellChecker):
 
     def compile_dictionary(self, lang, wordlists, output):
         """Compile user dictionary."""
+        wordlist = ''
 
-        output_location = os.path.dirname(output)
-        if not os.path.exists(output_location):
-            os.makedirs(output_location)
-        if os.path.exists(output):
-            os.remove(output)
+        try:
+            output_location = os.path.dirname(output)
+            if not os.path.exists(output_location):
+                os.makedirs(output_location)
+            if os.path.exists(output):
+                os.remove(output)
 
-        self.log("Compiling Dictionary...", 1)
-        # Read word lists and create a unique set of words
-        words = set()
-        for wordlist in wordlists:
-            with open(wordlist, 'rb') as src:
-                for word in src.read().split(b'\n'):
-                    words.add(word.replace(b'\r', b''))
+            self.log("Compiling Dictionary...", 1)
+            # Read word lists and create a unique set of words
+            words = set()
+            for wordlist in wordlists:
+                with open(wordlist, 'rb') as src:
+                    for word in src.read().split(b'\n'):
+                        words.add(word.replace(b'\r', b''))
 
-        # Sort and create wordlist
-        with open(output, 'wb') as dest:
-            dest.write(b'\n'.join(sorted(words)) + b'\n')
+            # Sort and create wordlist
+            with open(output, 'wb') as dest:
+                dest.write(b'\n'.join(sorted(words)) + b'\n')
+        except Exception:
+            self.log('Problem compiling dictionary.', 0)
+            self.log("Current wordlist '%s'" % wordlist)
+            raise
 
     def setup_command(self, encoding, options, personal_dict):
         """Setup command."""
@@ -387,10 +423,24 @@ def spellcheck(config_file, name='', binary='', verbose=0, checker=''):
     spellchecker = None
     config = settings.read_config(config_file)
 
-    for documents in config.get('documents', []):
+    matrix = config.get('matrix', [])
+    preferred_checker = config.get('spellchecker', 'aspell')
+    if not matrix:
+        matrix = config.get('documents', [])
+        if matrix:
+            warnings.warn(
+                "'documents' key in config is deprecated. 'matrix' should be used going forward.",
+                category=DeprecationWarning,
+                stacklevel=2
+            )
 
-        if name and name != documents.get('name', ''):
+    for task in matrix:
+
+        if name and name != task.get('name', ''):
             continue
+
+        if not checker:
+            checker = preferred_checker
 
         if checker == "hunspell":
             if hunspell is None:
@@ -404,6 +454,6 @@ def spellcheck(config_file, name='', binary='', verbose=0, checker=''):
         else:
             raise ValueError('%s is not a valid spellchecker!' % checker)
 
-        spellchecker.log('==> Using %s to spellcheck %s' % (checker, documents.get('name', '')), 1)
-        yield from spellchecker.check(documents)
+        spellchecker.log('==> Using %s to spellcheck %s' % (checker, task.get('name', '')), 1)
+        yield from spellchecker.run_task(task)
         spellchecker.log("", 1)

--- a/pyspelling/__init__.py
+++ b/pyspelling/__init__.py
@@ -151,7 +151,7 @@ class SpellChecker(object):
             if options is None:
                 options = {}
 
-            module = self._get_module(name, 'get_filter')
+            module = self._get_module(name, ('get_plugin', 'get_filter'))
             if issubclass(module, filters.Filter):
                 self.filters.append(module(options, **kwargs))
             elif issubclass(module, flow_control.FlowControl):
@@ -164,7 +164,10 @@ class SpellChecker(object):
 
         if isinstance(module, str):
             mod = importlib.import_module(module)
-        attr = getattr(mod, accessor, None)
+        for name in accessor:
+            attr = getattr(mod, name, None)
+            if attr is not None:
+                break
         if not attr:
             raise ValueError("Could not find accessor '%s'!" % accessor)
         return attr()

--- a/pyspelling/__main__.py
+++ b/pyspelling/__main__.py
@@ -14,7 +14,7 @@ def main():
     parser.add_argument('--verbose', '-v', action='count', default=0, help="Verbosity level.")
     parser.add_argument('--name', '-n', action='store', default='', help="Specific spelling task by name to run.")
     parser.add_argument('--binary', '-b', action='store', default='', help="Provide path to spell checker's binary.")
-    parser.add_argument('--config', '-c', action='store', default='.spelling.yml', help="Spelling config.")
+    parser.add_argument('--config', '-c', action='store', default='', help="Spelling config.")
     parser.add_argument(
         '--spellchecker', '-s', action='store', default='aspell', help="Choose between aspell and hunspell"
     )

--- a/pyspelling/__main__.py
+++ b/pyspelling/__main__.py
@@ -16,14 +16,14 @@ def main():
     parser.add_argument('--binary', '-b', action='store', default='', help="Provide path to spell checker's binary.")
     parser.add_argument('--config', '-c', action='store', default='', help="Spelling config.")
     parser.add_argument(
-        '--spellchecker', '-s', action='store', default='aspell', help="Choose between aspell and hunspell"
+        '--spellchecker', '-s', action='store', default='', help="Choose between aspell and hunspell"
     )
     args = parser.parse_args()
 
     return run(args.config, args.name, args.binary, args.verbose, args.spellchecker)
 
 
-def run(config, name='', binary='', verbose=0, spellchecker='aspell'):
+def run(config, name='', binary='', verbose=0, spellchecker=''):
     """Run."""
 
     fail = False

--- a/pyspelling/filters/context.py
+++ b/pyspelling/filters/context.py
@@ -36,12 +36,12 @@ class ContextFilter(filters.Filter):
         with codecs.open(source_file, 'r', encoding=encoding) as f:
             text = f.read()
 
-        return [filters.SourceText(self._filter(text), source_file, encoding, 'text')]
+        return [filters.SourceText(self._filter(text), source_file, encoding, 'context')]
 
     def sfilter(self, source):
         """Filter."""
 
-        return [filters.SourceText(self._filter(source.text), source.context, source.encoding, 'text')]
+        return [filters.SourceText(self._filter(source.text), source.context, source.encoding, 'context')]
 
     def _filter(self, text):
         """Context delimiter filter."""
@@ -51,7 +51,7 @@ class ContextFilter(filters.Filter):
         last = 0
         end = len(text)
         while index < end:
-            m = self.escapes.match(text, pos=index)
+            m = self.escapes.match(text, pos=index) if self.escapes else None
             if m:
                 index = m.end(0)
                 continue

--- a/pyspelling/filters/context.py
+++ b/pyspelling/filters/context.py
@@ -76,7 +76,7 @@ class ContextFilter(filters.Filter):
         return ' '.join(new_text)
 
 
-def get_filter():
+def get_plugin():
     """Return the filter."""
 
     return ContextFilter

--- a/pyspelling/filters/cpp.py
+++ b/pyspelling/filters/cpp.py
@@ -132,7 +132,7 @@ class CppFilter(filters.Filter):
         return self._filter(source.text, source.context, source.encoding)
 
 
-def get_filter():
+def get_plugin():
     """Get filter."""
 
     return CppFilter

--- a/pyspelling/filters/cpp.py
+++ b/pyspelling/filters/cpp.py
@@ -47,7 +47,7 @@ class CppFilter(filters.Filter):
     def evaluate_inline(self, groups):
         """Evaluate inline comments on their own lines."""
 
-        # Cosecutive lines with only comments with same leading whitespace
+        # Consecutive lines with only comments with same leading whitespace
         # will be captured as a single block.
         if self.lines:
             if (

--- a/pyspelling/filters/cpp.py
+++ b/pyspelling/filters/cpp.py
@@ -1,0 +1,138 @@
+"""C++ filter."""
+import re
+import codecs
+from .. import filters
+import textwrap
+
+RE_COMMENT = re.compile(
+    r'''(?x)
+        (?P<comments>
+            (?P<block>/\*[^*]*\*+(?:[^/*][^*]*\*+)*/)                        # multi-line comments
+          | (?P<start>^)?(?P<leading_space>[ \t]*)?(?P<line>//(?:[^\r\n])*)  # single line comments
+        )
+      | (?P<code>
+            "(?:\\.|[^"\\])*"                                                # double quotes
+            '(?:\\.|[^'\\])*'                                                # single quotes
+          | .[^/"']*?                                                        # everything else
+        )
+    ''',
+    re.DOTALL | re.MULTILINE
+)
+
+
+class CppFilter(filters.Filter):
+    """C++ style comment filter."""
+
+    def __init__(self, options, default_encoding='utf-8'):
+        """Initialization."""
+
+        self.blocks = options.get('block_comments', True) is True
+        self.lines = options.get('line_comments', True) is True
+        self.group_comments = options.get('group_comments', False) is True
+        self.prefix = options.get('prefix', 'cpp')
+        super(CppFilter, self).__init__(options, default_encoding)
+
+    def evaluate_block(self, groups):
+        """Evaluate block comments."""
+
+        if self.blocks:
+            self.block_comments.append([groups['block'][2:-2], self.line_num])
+
+    def evaluate_inline_tail(self, groups):
+        """Evaluate inline comments at the tail of source code."""
+
+        if self.lines:
+            self.line_comments.append([groups['line'][2:], self.line_num])
+
+    def evaluate_inline(self, groups):
+        """Evaluate inline comments on their own lines."""
+
+        # Cosecutive lines with only comments with same leading whitespace
+        # will be captured as a single block.
+        if self.lines:
+            if (
+                self.group_comments and
+                self.line_num == self.prev_line + 1 and
+                groups['leading_space'] == self.leading
+            ):
+                self.line_comments[-1][0] += '\n' + groups['line'][2:]
+            else:
+                self.line_comments.append([groups['line'][2:], self.line_num])
+            self.leading = groups['leading_space']
+            self.prev_line = self.line_num
+
+    def _evaluate(self, m):
+        """Search for comments."""
+
+        g = m.groupdict()
+        if g["code"]:
+            self.line_num += g["code"].count('\n')
+        else:
+            if g['block']:
+                self.evaluate_block(g)
+            elif g['start'] is None:
+                self.evaluate_inline_tail(g)
+            else:
+                self.evaluate_inline(g)
+            self.line_num += g['comments'].count('\n')
+
+    def extend_src_text(self, content, context, text_list, encoding, category):
+        """Extend the source text list with the gathered text data."""
+
+        prefix = self.prefix + '-' if self.prefix else ''
+
+        for comment, line in text_list:
+            content.append(
+                filters.SourceText(
+                    textwrap.dedent(comment),
+                    "%s (%d)" % (context, line),
+                    encoding,
+                    prefix + category
+                )
+            )
+
+    def extend_src(self, content, context, encoding):
+        """Extend source list."""
+
+        self.extend_src_text(content, context, self.block_comments, encoding, 'block-comment')
+        self.extend_src_text(content, context, self.line_comments, encoding, 'line-comment')
+
+    def find_comments(self, text):
+        """Find comments."""
+
+        for m in RE_COMMENT.finditer(text):
+            self._evaluate(m)
+
+    def _filter(self, text, context, encoding):
+        """Filter JavaScript comments."""
+
+        content = []
+        self.line_num = 1
+        self.prev_line = -1
+        self.leading = ''
+        self.block_comments = []
+        self.line_comments = []
+
+        self.find_comments(text)
+        self.extend_src(content, context, encoding)
+
+        return content
+
+    def filter(self, source_file, encoding):  # noqa A001
+        """Parse HTML file."""
+
+        with codecs.open(source_file, 'r', encoding=encoding) as f:
+            text = f.read()
+
+        return self._filter(text, source_file, encoding)
+
+    def sfilter(self, source):
+        """Filter."""
+
+        return self._filter(source.text, source.context, source.encoding)
+
+
+def get_filter():
+    """Get filter."""
+
+    return CppFilter

--- a/pyspelling/filters/html.py
+++ b/pyspelling/filters/html.py
@@ -348,7 +348,7 @@ class HtmlFilter(filters.Filter):
         return self._filter(source.text, source.context, source.encoding)
 
 
-def get_filter():
+def get_plugin():
     """Return the filter."""
 
     return HtmlFilter

--- a/pyspelling/filters/javascript.py
+++ b/pyspelling/filters/javascript.py
@@ -45,7 +45,7 @@ class JavaScriptFilter(cpp.CppFilter):
         return super(JavaScriptFilter, self)._filter(text, context, encoding)
 
 
-def get_filter():
+def get_plugin():
     """Get filter."""
 
     return JavaScriptFilter

--- a/pyspelling/filters/javascript.py
+++ b/pyspelling/filters/javascript.py
@@ -1,144 +1,48 @@
 """JavaScript filter."""
 import re
-import codecs
-from .. import filters
-import textwrap
+from . import cpp
 
-RE_LINE_PRESERVE = re.compile(r"\r?\n", re.MULTILINE)
 RE_JSDOC = re.compile(r"(?s)^/\*\*$(.*?)[ \t]*\*/", re.MULTILINE)
-RE_COMMENT = re.compile(
-    r'''(?x)
-        (?P<comments>
-            (?P<block>/\*[^*]*\*+(?:[^/*][^*]*\*+)*/)                        # multi-line comments
-          | (?P<start>^)?(?P<leading_space>[ \t]*)?(?P<line>//(?:[^\r\n])*)  # single line comments
-        )
-      | (?P<code>
-            "(?:\\.|[^"\\])*"                                                # double quotes
-            '(?:\\.|[^'\\])*'                                                # single quotes
-          | .[^/"']*?                                                        # everything else
-        )
-    ''',
-    re.DOTALL | re.MULTILINE
-)
 
 
-class JavaScriptFilter(filters.Filter):
+class JavaScriptFilter(cpp.CppFilter):
     """JavaScript filter."""
 
     def __init__(self, options, default_encoding='utf-8'):
         """Initialization."""
 
-        self.blocks = options.get('block_comments', True) is True
-        self.lines = options.get('line_comments', True) is True
-        # self.strings = options.get('strings', False) is True
-        self.group_comments = options.get('group_comments', False) is True
         self.jsdocs = options.get('jsdocs', False) is True
+        options['prefix'] = 'js'
         super(JavaScriptFilter, self).__init__(options, default_encoding)
 
-    def _evaluate(self, m):
-        """Search for comments."""
+    def evaluate_block(self, groups):
+        """Evaluate block comments."""
 
-        g = m.groupdict()
-        if g["code"]:
-            text = g["code"]
-            self.line_num += text.count('\n')
-        else:
-            if g['block']:
-                if self.jsdocs:
-                    m1 = RE_JSDOC.match(g['comments'])
-                    if m1:
-                        lines = []
-                        for line in m1.group(1).splitlines(True):
-                            l = line.lstrip()
-                            lines.append(l[1:] if l.startswith('*') else l)
-                        self.jsdoc_comments.append([''.join(lines), self.line_num])
-                    elif self.blocks:
-                        self.block_comments.append([g['block'][2:-2], self.line_num])
-                elif self.blocks:
-                    self.block_comments.append([g['block'][2:-2], self.line_num])
-                self.line_num += g['comments'].count('\n')
-            elif self.lines:
-                if g['start'] is None:
-                    self.line_comments.append([g['line'][2:], self.line_num])
-                    self.line_num += g['comments'].count('\n')
-                else:
-                    # Cosecutive lines with only comments with same leading whitespace
-                    # will be captured as a single block.
-                    if (
-                        self.group_comments and
-                        self.line_num == self.prev_line + 1 and
-                        g['leading_space'] == self.leading
-                    ):
-                        self.line_comments[-1][0] += '\n' + g['line'][2:]
-                    else:
-                        self.line_comments.append([g['line'][2:], self.line_num])
-                    self.leading = g['leading_space']
-                    self.line_num += g['comments'].count('\n')
-                    self.prev_line = self.line_num
-            else:
-                self.line_num += g['comments'].count('\n')
-            text = ''.join([x[0] for x in RE_LINE_PRESERVE.findall(g["comments"])])
-        return text
+        if self.jsdocs:
+            m1 = RE_JSDOC.match(groups['comments'])
+            if m1:
+                lines = []
+                for line in m1.group(1).splitlines(True):
+                    l = line.lstrip()
+                    lines.append(l[1:] if l.startswith('*') else l)
+                self.jsdoc_comments.append([''.join(lines), self.line_num])
+            elif self.blocks:
+                self.block_comments.append([groups['block'][2:-2], self.line_num])
+        elif self.blocks:
+            self.block_comments.append([groups['block'][2:-2], self.line_num])
 
-    def find_comments(self, text):
-        """Find comments."""
+    def extend_src(self, content, context, encoding):
+        """Extend source list."""
 
-        return ''.join(map(lambda m: self._evaluate(m), RE_COMMENT.finditer(text)))
+        self.extend_src_text(content, context, self.block_comments, encoding, 'block-comment')
+        self.extend_src_text(content, context, self.line_comments, encoding, 'line-comment')
+        self.extend_src_text(content, context, self.jsdoc_comments, encoding, 'docs')
 
     def _filter(self, text, context, encoding):
         """Filter JavaScript comments."""
 
-        content = []
-        self.line_num = 1
-        self.prev_line = -1
-        self.leading = ''
         self.jsdoc_comments = []
-        self.block_comments = []
-        self.line_comments = []
-
-        self.find_comments(text)
-        for comment, line in self.jsdoc_comments:
-            content.append(
-                filters.SourceText(
-                    textwrap.dedent(comment),
-                    "%s (%d)" % (context, line),
-                    encoding,
-                    'jsdocs'
-                )
-            )
-        for comment, line in self.block_comments:
-            content.append(
-                filters.SourceText(
-                    textwrap.dedent(comment),
-                    "%s (%d)" % (context, line),
-                    encoding,
-                    'block-comment'
-                )
-            )
-        for comment, line in self.line_comments:
-            content.append(
-                filters.SourceText(
-                    textwrap.dedent(comment),
-                    "%s (%d)" % (context, line),
-                    encoding,
-                    'line-comment'
-                )
-            )
-
-        return content
-
-    def filter(self, source_file, encoding):  # noqa A001
-        """Parse HTML file."""
-
-        with codecs.open(source_file, 'r', encoding=encoding) as f:
-            text = f.read()
-
-        return self._filter(text, source_file, encoding)
-
-    def sfilter(self, source):
-        """Filter."""
-
-        return self._filter(source.text, source.context, source.encoding)
+        return super(JavaScriptFilter, self)._filter(text, context, encoding)
 
 
 def get_filter():

--- a/pyspelling/filters/markdown.py
+++ b/pyspelling/filters/markdown.py
@@ -43,7 +43,7 @@ class MarkdownFilter(filters.Filter):
         return [filters.SourceText(self._filter(source.text), source.context, source.encoding, 'markdown')]
 
 
-def get_filter():
+def get_plugin():
     """Return the filter."""
 
     return MarkdownFilter

--- a/pyspelling/filters/python.py
+++ b/pyspelling/filters/python.py
@@ -151,7 +151,7 @@ class PythonFilter(filters.Filter):
         return self._filter(source.text, source.context, source.encoding)
 
 
-def get_filter():
+def get_plugin():
     """Return the filter."""
 
     return PythonFilter

--- a/pyspelling/filters/stylesheets.py
+++ b/pyspelling/filters/stylesheets.py
@@ -65,7 +65,7 @@ class StylesheetsFilter(cpp.CppFilter):
             self.extend_src_text(content, context, self.line_comments, encoding, 'line-comment')
 
 
-def get_filter():
+def get_plugin():
     """Get filter."""
 
     return StylesheetsFilter

--- a/pyspelling/filters/stylesheets.py
+++ b/pyspelling/filters/stylesheets.py
@@ -1,0 +1,71 @@
+"""Stylesheets filter."""
+import re
+from . import cpp
+
+RE_CSS_COMMENT = re.compile(
+    r'''(?x)
+        (?P<comments>
+            (?P<block>/\*[^*]*\*+(?:[^/*][^*]*\*+)*/)                        # multi-line comments
+        )
+      | (?P<code>
+            "(?:\\.|[^"\\])*"                                                # double quotes
+            '(?:\\.|[^'\\])*'                                                # single quotes
+          | .[^/"']*?                                                        # everything else
+        )
+    ''',
+    re.DOTALL | re.MULTILINE
+)
+
+CSS = 0
+SASS = 1
+SCSS = 2
+
+STYLESHEET_TYPE = {
+    "css": CSS,
+    "sass": SASS,
+    "scss": SCSS
+}
+
+
+class StylesheetsFilter(cpp.CppFilter):
+    """Stylesheets filter."""
+
+    def __init__(self, options, default_encoding='utf-8'):
+        """Initialization."""
+
+        # If the style isn't found, just go with CSS, then use the appropriate prefix.
+        self.stylesheets = STYLESHEET_TYPE.get(options.get('stylesheets', 'css').lower(), CSS)
+        self.prefix = [k for k, v in STYLESHEET_TYPE.items() if v == SASS][0]
+        super(StylesheetsFilter, self).__init__(options, default_encoding)
+
+    def find_comments(self, text):
+        """Find comments."""
+
+        if self.stylesheets == CSS:
+            for m in RE_CSS_COMMENT.finditer(text):
+                self._css_evaluate(m)
+        else:
+            super(StylesheetsFilter, self).find_comments(text)
+
+    def _css_evaluate(self, m):
+        """Search for comments."""
+
+        g = m.groupdict()
+        if g["code"]:
+            self.line_num += g["code"].count('\n')
+        else:
+            self.evaluate_block(g)
+            self.line_num += g['comments'].count('\n')
+
+    def extend_src(self, content, context, encoding):
+        """Extend source list."""
+
+        self.extend_src_text(content, context, self.block_comments, encoding, 'block-comment')
+        if self.stylesheets != CSS:
+            self.extend_src_text(content, context, self.line_comments, encoding, 'line-comment')
+
+
+def get_filter():
+    """Get filter."""
+
+    return StylesheetsFilter

--- a/pyspelling/filters/text.py
+++ b/pyspelling/filters/text.py
@@ -59,7 +59,7 @@ class TextFilter(filters.Filter):
         return [filters.SourceText(text, source.context, encoding, 'text')]
 
 
-def get_filter():
+def get_plugin():
     """Return the filter."""
 
     return TextFilter

--- a/pyspelling/flow_control/__init__.py
+++ b/pyspelling/flow_control/__init__.py
@@ -1,0 +1,43 @@
+"""Flow control."""
+from wcmatch import fnmatch
+
+
+ALLOW = 0
+SKIP = 1
+HALT = 2
+
+
+class FlowControl:
+    """Control flow of objects in the pipeline."""
+
+    FNMATCH_FLAGS = fnmatch.N | fnmatch.B
+
+    def __init__(self, config):
+        """Initialization."""
+
+        self.allow = config.get('allow', ['*'])
+        self.halt = config.get('halt', [])
+        self.skip = config.get('skip', [])
+
+    def adjust_flow(self, category):
+        """Adjust the flow of source control objects."""
+
+        status = SKIP
+        for allow in self.allow:
+            if fnmatch.fnmatch(category, allow, flags=self.FNMATCH_FLAGS):
+                status = ALLOW
+                for skip in self.skip:
+                    if fnmatch.fnmatch(category, skip, flags=self.FNMATCH_FLAGS):
+                        status = SKIP
+                for halt in self.halt:
+                    if fnmatch.fnmatch(category, halt, flags=self.FNMATCH_FLAGS):
+                        status = HALT
+                if status != ALLOW:
+                    break
+        return status
+
+
+def get_filter():
+    """Get flow controller."""
+
+    return FlowControl

--- a/pyspelling/flow_control/__init__.py
+++ b/pyspelling/flow_control/__init__.py
@@ -37,7 +37,7 @@ class FlowControl:
         return status
 
 
-def get_filter():
+def get_plugin():
     """Get flow controller."""
 
     return FlowControl

--- a/pyspelling/settings.py
+++ b/pyspelling/settings.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import yaml
 import codecs
 import os
+import warnings
 
 __all__ = ("yaml_load", "read_config")
 
@@ -34,6 +35,12 @@ def read_config(file_name):
     config = {}
     for name in (['.pyspelling.yml', '.spelling.yml'] if not file_name else [file_name]):
         if os.path.exists(name):
+            if not file_name and name == '.spelling.yml':
+                warnings.warn(
+                    "Using '.spelling.yml' as the default is deprecated. Default config is now '.pyspelling.yml'",
+                    category=DeprecationWarning,
+                    stacklevel=2
+                )
             with codecs.open(name, 'r', encoding='utf-8') as f:
                 config = yaml_load(f.read())
             break

--- a/pyspelling/settings.py
+++ b/pyspelling/settings.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 import yaml
 import codecs
+import os
 
 __all__ = ("yaml_load", "read_config")
 
@@ -31,6 +32,9 @@ def read_config(file_name):
     """Read configuration."""
 
     config = {}
-    with codecs.open(file_name, 'r', encoding='utf-8') as f:
-        config = yaml_load(f.read())
+    for name in (['.pyspelling.yml', '.spelling.yml'] if not file_name else [file_name]):
+        if os.path.exists(name):
+            with codecs.open(name, 'r', encoding='utf-8') as f:
+                config = yaml_load(f.read())
+            break
     return config

--- a/pyspelling/util.py
+++ b/pyspelling/util.py
@@ -6,9 +6,35 @@ import string
 import random
 import re
 import locale
+from functools import wraps
 from collections import namedtuple
+import warnings
 
 RE_LAST_SPACE_IN_CHUNK = re.compile(rb'(\s+)(?=\S+\Z)')
+
+
+def deprecated(message):  # pragma: no cover
+    """
+    Raise a `DeprecationWarning` when wrapped function/method is called.
+
+    Borrowed from https://stackoverflow.com/a/48632082/866026
+    """
+
+    def deprecated_decorator(func):
+        """Deprecation decorator."""
+
+        @wraps(func)
+        def deprecated_func(*args, **kwargs):
+            """Display deprecation warning."""
+
+            warnings.warn(
+                "'{}' is deprecated. {}".format(func.__name__, message),
+                category=DeprecationWarning,
+                stacklevel=2
+            )
+            return func(*args, **kwargs)
+        return deprecated_func
+    return deprecated_decorator
 
 
 def get_process(cmd):

--- a/pyspelling/util.py
+++ b/pyspelling/util.py
@@ -75,8 +75,8 @@ def call_spellchecker(cmd, input_text, encoding=None):
 
     if input_text is not None:
         for line in input_text.splitlines():
-            # Hunspell truncates lines at 0x1fff (at least on Windows this has been observed)
-            # Avoid trunctation by chunking the line on white space and inserting a new line to break it.
+            # Hunspell truncates lines at `0x1fff` (at least on Windows this has been observed)
+            # Avoid truncation by chunking the line on white space and inserting a new line to break it.
             offset = 0
             end = len(line)
             while True:


### PR DESCRIPTION
- Better context for HTML elements. HTML is now returned by block level elements, and the elements selector is given as context. Attributes also return a selector as context and are returned individually. Html comments are returned as individual hunks.
- Add Stylesheet and cpp filters (#17)
- JavaScript is now derived from cpp.
- PySpelling looks for .spelling.yml or .pyspelling.yml with a priority for the latter. (#12)
- Fix context issue when no escapes are defined.
- Spelling pipeline adjustments: you can now explicitly allow only certain categories, skip categories, or halt them in the pipeline. Pipeline flow control is now done via a new FlowControl plugin.  When avoiding, including, or skipping categories, they are now done with wildcard patterns. (#16)
- Scan inline Python comments for spelling errors. Drop scanning python normal strings.
- Use get_plugin instead of get_filter, but allow a backwards compatible path for now.
- In config, `documents` is now `matrix` and `filters` is not `pipeline`, but a deprecation path has been added. (#15)
- Add global config option to specify the preferred spellchecker, but it is still overridable via command line.
- Internal cleanup with renaming, adding other deprecation warnings, and logging for specific errors.