### PR TITLE
Fix cpp comment detection

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0b2
+
+- **FIX**: Fix CPP comment regular expression.
+
 ## 1.0.0b1
 
 - **NEW**: Better context for HTML elements. HTML is now returned by block level elements, and the elements selector is given as context. Attributes also return a selector as context and are returned individually. HTML comments are returned as individual hunks.

--- a/pyspelling/__meta__.py
+++ b/pyspelling/__meta__.py
@@ -1,7 +1,7 @@
 """`PySpelling` package."""
 
 #   (major, minor, micro, release type, pre-release build, post-release build, development-release)
-version_info = (1, 0, 0, 'beta', 1, 0)
+version_info = (1, 0, 0, 'beta', 2, 0)
 
 
 def pep440_version(vi):

--- a/pyspelling/filters/cpp.py
+++ b/pyspelling/filters/cpp.py
@@ -7,13 +7,13 @@ import textwrap
 RE_COMMENT = re.compile(
     r'''(?x)
         (?P<comments>
-            (?P<block>/\*[^*]*\*+(?:[^/*][^*]*\*+)*/)                        # multi-line comments
-          | (?P<start>^)?(?P<leading_space>[ \t]*)?(?P<line>//(?:[^\r\n])*)  # single line comments
-        )
-      | (?P<code>
-            "(?:\\.|[^"\\])*"                                                # double quotes
-            '(?:\\.|[^'\\])*'                                                # single quotes
-          | .[^/"']*?                                                        # everything else
+            (?P<block>/\*[^*]*\*+(?:[^/*][^*]*\*+)*/) |                      # multi-line comments
+            (?P<start>^)?(?P<leading_space>[ \t]*)?(?P<line>//(?:[^\r\n])*)  # single line comments
+        ) |
+        (?P<code>
+            "(?:\\.|[^"\\])*" |                                              # double quotes
+            '(?:\\.|[^'\\])*' |                                              # single quotes
+            .[^/"']*?                                                        # everything else
         )
     ''',
     re.DOTALL | re.MULTILINE

--- a/pyspelling/filters/stylesheets.py
+++ b/pyspelling/filters/stylesheets.py
@@ -6,11 +6,11 @@ RE_CSS_COMMENT = re.compile(
     r'''(?x)
         (?P<comments>
             (?P<block>/\*[^*]*\*+(?:[^/*][^*]*\*+)*/)                        # multi-line comments
-        )
-      | (?P<code>
-            "(?:\\.|[^"\\])*"                                                # double quotes
-            '(?:\\.|[^'\\])*'                                                # single quotes
-          | .[^/"']*?                                                        # everything else
+        ) |
+        (?P<code>
+            "(?:\\.|[^"\\])*" |                                              # double quotes
+            '(?:\\.|[^'\\])*' |                                              # single quotes
+            .[^/"']*?                                                        # everything else
         )
     ''',
     re.DOTALL | re.MULTILINE


### PR DESCRIPTION
During refactoring, it looks like we removed a pipe from the regex which broke string finding.