### PR TITLE
String support

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -89,6 +89,7 @@ subclassing
 sublicense
 substring
 syntaxes
+trigraphs
 tuple
 validator
 whitespace

--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -69,6 +69,7 @@ macOS
 matcher
 metadata
 mkdocs
+multiline
 namespace
 namespaces
 overridable

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -18,6 +18,8 @@
 - **NEW**: Tasks can be hidden with the `hidden` configuration option. Tasks with `hidden` enabled will only run if they are explicitly called by name.
 - **NEW**: Add normal string support to Python filter.
 - **NEW**: Add string support for JavaScript filter.
+- **NEW**: Add string support for CPP filter.
+- **NEW**: Add `generic_mode` option to CPP to allow for generic C/C++ comment style capture from non C/C++ file types.
 - **NEW**: Context will normalize line endings before applying context (can be disabled).
 - **NEW**: CPP and plugins derived from CPP now normalize line endings of block comments.
 - **FIX**: Case related issues when comparing tags and attributes in HTML.

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -16,6 +16,9 @@
 - **NEW**: Support modes added for HTML filter: `html`, `html5`, `xhtml`.
 - **NEW**: `CHECK_BOM` plugin attribute has been deprecated in favor of overriding the exposed `has_bom` function.
 - **NEW**: Tasks can be hidden with the `hidden` configuration option. Tasks with `hidden` enabled will only run if they are explicitly called by name.
+- **NEW**: Add normal string support to Python filter.
+- **NEW**: Context will normalize line endings before applying context (can be disabled).
+- **NEW**: CPP and plugins derived from CPP now normalize line endings of block comments.
 - **FIX**: Case related issues when comparing tags and attributes in HTML.
 - **FIX**: CSS selectors should only compare case insensitive for ASCII characters A-Z and a-z.
 - **FIX**: Allow CSS escapes in selectors.

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -17,6 +17,7 @@
 - **NEW**: `CHECK_BOM` plugin attribute has been deprecated in favor of overriding the exposed `has_bom` function.
 - **NEW**: Tasks can be hidden with the `hidden` configuration option. Tasks with `hidden` enabled will only run if they are explicitly called by name.
 - **NEW**: Add normal string support to Python filter.
+- **NEW**: Add string support for JavaScript filter.
 - **NEW**: Context will normalize line endings before applying context (can be disabled).
 - **NEW**: CPP and plugins derived from CPP now normalize line endings of block comments.
 - **FIX**: Case related issues when comparing tags and attributes in HTML.

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -23,6 +23,7 @@
 - **FIX**: CSS selectors should only compare case insensitive for ASCII characters A-Z and a-z.
 - **FIX**: Allow CSS escapes in selectors.
 - **FIX**: Don't send empty (or strings that are just whitespace) to spell checker to prevent Aspell 0.50 series from crashing (also to increase performance).
+- **FIX**: Catch and bubble up errors better.
 
 ## 1.1.0
 

--- a/docs/src/markdown/filters/cpp.md
+++ b/docs/src/markdown/filters/cpp.md
@@ -2,9 +2,25 @@
 
 ## Usage
 
-The CPP plugin is designed to find and return C/C++ style comments. When first in the chain, the CPP filter uses no special encoding detection. It will assume `utf-8` if no encoding BOM is found, and the user has not overridden the fallback encoding. Text is returned in chunks based on the context of the text: block or inline.
+The CPP plugin is designed to find and return C/C++ style comments. When first in the chain, the CPP filter uses no special encoding detection. It will assume `utf-8` if no encoding BOM is found, and the user has not overridden the fallback encoding. Text is returned in chunks based on the context of the text: block, inline, or string (if enabled).
 
-As C++ style comments are fairly common convention in other languages, this can often be used for other syntaxes. The JavaScript and Stylesheets plugin are actually derived from this one. If using this for another syntax language, you can actually augment the returned categories by providing an alternative prefix to via the options.  The default is `cpp`.
+When the `strings` [option](#options) is enabled, content will be extracted from strings (not character constants). Support is available for all the modern C++ strings shown below. CPP will also handle decoding string escapes as well, but as string character width and encoding can be dependent on implementation and configuration, some additional setup may be required via [option](#options).
+
+```c++
+    auto s0 =    "Narrow character string";                   // char
+    auto s1 =   L"Wide character string";                     // wchar_t
+    auto s2 =  u8"UTF-8 strings";                             // char
+    auto s3 =   u"UTF-16 strings";                            // char16_t
+    auto s4 =   U"UTF-32 strings";                            // char32_t
+    auto R0 =   R"("Raw strings")";                           // const char*
+    auto R1 =   R"delim("Raw strings with delimiters")delim"; // const char*
+    auto R3 =  LR"("Raw wide character strings")";            // const wchar_t*
+    auto R4 = u8R"("Raw UTF-8 strings")";                     // const char*, encoded as UTF-8
+    auto R5 =  uR"("Raw UTF-16 strings")";                    // const char16_t*, encoded as UTF-16
+    auto R6 =  UR"("Raw UTF-32 strings")";                    // const char32_t*, encoded as UTF-32
+```
+
+As C++ style comments are fairly common convention in other languages, this filter can often be used for other languages as well using `generic_mode`. In Generic Mode, many C/C++ specific considerations and options will be disabled. See [Generic Mode] for more information.
 
 ```yaml
 matrix:
@@ -16,19 +32,47 @@ matrix:
   - js_files/**/*.{cpp,hpp,c,h}
 ```
 
+## Generic Mode
+
+C/C++ style comments are not exclusive to C/C++. Many different file types have adopted similar style comments. The CPP filter has a generic mode which allows for a C/C++ style comment extraction without all the C/C++ specific considerations. Simply enable `generic_mode` via the [options](#options).
+
+Generic Mode disables the C/C++ specific nuance of allowing multiline comments via escaping newlines. This is a very C/C++ specific thing that is rarely carried over by others that have adopted C/C++ style comments:
+
+```c++
+// Generic mode will \
+   not allow this.
+```
+
+Generic Mode will not decode any character escapes in strings when enabled. C/C++ has very specific rules for handling string escapes, only a handful of which may translate to other languages. Generic Mode is mainly meant for comments and not strings, but will return content of single quoted and double quoted strings if `strings` is enabled. All related escape decoding options do not apply to Generic Mode.
+
+Trigraphs are very C/C++ specific, and will never be evaluated in Generic Mode.
+
+Lastly, when using this filter in Generic Mode, you can also adjust the category prefix from `cpp` to whatever you would like via the `prefix` [option](#options).
+
 ## Options
 
-Options          | Type     | Default       | Description
----------------- | -------- | ------------- | -----------
-`block_comments` | bool     | `#!py3 True`  | Return `SourceText` entries for each block comment.
-`line_comments`  | bool     | `#!py3 True`  | Return `SourceText` entries for each line comment.
-`group_comments` | bool     | `#!py3 False` | Group consecutive inline comments as one `SourceText` entry.
+Options            | Type     | Default         | Description
+------------------ | -------- | --------------- | -----------
+`block_comments`   | bool     | `#!py3 True`    | Return `SourceText` entries for each block comment.
+`line_comments`    | bool     | `#!py3 True`    | Return `SourceText` entries for each line comment.
+`strings`          | bool     | `#!py3 False`   | Return `SourceText` entries for each string.
+`group_comments`   | bool     | `#!py3 False`   | Group consecutive inline comments as one `SourceText` entry.
+`trigraphs`        | bool     | `#!py3 False`   | Account for trigraphs in C/C++ code. Trigraphs are never evaluated in [Generic Mode](#generic-mode).
+`generic_mode`     | bool     | `#!py3 False`   | Parses files with a generic C++ like mode for parsing C++ style comments from non C++ files. See [Generic Mode](#generic-mode) for more info.
+`decode_escapes`   | bool     | `#!py3 True`    | Enable/disable string escape decoding. Strings are never decoded in [Generic Mode](#generic-mode).
+`charset_size`     | int      | `#!py3 1`       | Set normal string character byte width.
+`exec_charset`     | string   | `#!py3 'utf-8`  | Set normal string encoding.
+`wide_charset_size`| int      | `#!py3 4`       | Set wide string character byte width.
+`wide_exec_charset`| string   | `#!py3 'utf-32` | Set wide string encoding.
+`allowed`          | string   | `#!py3 "suw"`   | Set the allowed string types to capture: standard strings (`s`),  wide (`wide`), Unicode (`u`), and raw (`r`).
+`prefix`           | string   | `#!py3 'cpp'`   | Change the category prefix.
 
 ## Categories
 
-JavaScript returns text with the following categories.
+CPP returns text with the following categories. `cpp` prefix can be changed via the `prefix` [option](#options).
 
 Category            | Description
 ------------------- | -----------
 `cpp-block-comment` | Text captured from C++ style block comments.
 `cpp-line-comment`  | Text captured from C++ style line comments.
+`cpp-string`        | Text captured from strings.

--- a/docs/src/markdown/filters/javascript.md
+++ b/docs/src/markdown/filters/javascript.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-When first in the chain, the JavaScript filter uses no special encoding detection. It will assume `utf-8` if no encoding BOM is found, and the user has not overridden the fallback encoding. Text is returned in chunks based on the context of the text.  The filter can return JSDoc comments, block comments, and/or inline comments.
+When first in the chain, the JavaScript filter uses no special encoding detection. It will assume `utf-8` if no encoding BOM is found, and the user has not overridden the fallback encoding. Text is returned in chunks based on the context of the text.  The filter can return JSDoc comments, block comments, inline comments, and string content.
 
 ```yaml
 matrix:
@@ -23,7 +23,9 @@ Options          | Type     | Default       | Description
 `block_comments` | bool     | `#!py3 True`  | Return `SourceText` entries for each block comment.
 `line_comments`  | bool     | `#!py3 True`  | Return `SourceText` entries for each line comment.
 `jsdocs`         | bool     | `#!py3 False` | Return `SourceText` entries for each JSDoc comment.
+`strings`        | bool     | `#!py3 False` | Return `SourceText` entries for each string.
 `group_comments` | bool     | `#!py3 False` | Group consecutive inline JavaScript comments as one `SourceText` entry.
+`decode_escapes` | bool     | `#!py3 True`  | Enable/disable decoding of string escapes.
 
 ## Categories
 
@@ -34,3 +36,4 @@ Category           | Description
 `js-block-comment` | Text captured from JavaScript block comments.
 `js-line-comment`  | Text captured from JavaScript line comments.
 `js-docs`          | Text captured from JSDoc comments.
+`js-string`        | Text captured from strings.

--- a/docs/src/markdown/filters/python.md
+++ b/docs/src/markdown/filters/python.md
@@ -24,6 +24,8 @@ Options          | Type     | Default       | Description
 `comments`       | bool     | `#!py3 True`  | Return `SourceText` entries for each comment.
 `docstrings`     | bool     | `#!py3 True`  | Return `SourceText` entries for each docstrings.
 `group_comments` | bool     | `#!py3 False` | Group consecutive Python comments as one `SourceText` entry.
+`strings`        | string   | `#!py3 False` | Return `SourceText` entries for each string (non-docstring).
+`allowed`        | string   | `#!py3 fu`    | Specifies which string types `strings` searches: bytes (`b`), format (`f`), raw (`r`), and Unicode (`u`). 
 
 ## Categories
 
@@ -33,3 +35,4 @@ Category       | Description
 -------------- | -----------
 `py-comments`  | Text captured from inline comments.
 `py-docstring` | Text captured from docstrings.
+`py-string`    | Text captured from strings.

--- a/docs/src/markdown/filters/python.md
+++ b/docs/src/markdown/filters/python.md
@@ -4,7 +4,13 @@
 
 When first in the chain, the Python filter will look for the encoding of the file in the header, and convert to Unicode accordingly. It will assume `utf-8` if no encoding header is found, and the user has not overridden the fallback encoding.
 
-Text is returned in chunks based on the context of the captured text. Each docstrings and inline comments is returned as their own chunk.
+Text is returned in chunks based on the context of the captured text. Each docstrings, inline comment, or non-docstring is returned as their own chunk.
+
+In general, regardless of Python version, strings *should* be parsed *almost* identically. PySpelling, unless configured otherwise, will decode string escapes and strip out format variables from f-strings. Decoding of escapes and stripping format variables is not dependent on what version of Python PySpelling is run on, but is based on the string prefixes that PySpelling encounters. There are two cases that may cause quirks related to Python version:
+
+1. PySpelling doesn't support being run from Python 2, but it will still find strings and comments in Python 2 code as many Python 3 projects support Python 2 as well. If you run this on Python 2 code that is not using `#!py3 from __future__ import unicode_literals`, it will still treat the default strings in Python 2 code as Unicode as it has no way of knowing that a file is specifically meant for Python 2 parsing only. In general, you should use `unicode_literals` if you are supporting both Python 2 and 3.
+
+2. Use of `\N{NAMED UNICODE}` *might* produce different results if one Python version defines a specific Unicode name while another does not. I'm not sure how greatly the named Unicode database varies from Python version to Python version, but if this is experienced, and is problematic, you can always disable `decode_escapes` in the options for a more consistent behavior.
 
 ```yaml
 matrix:
@@ -24,8 +30,9 @@ Options          | Type     | Default       | Description
 `comments`       | bool     | `#!py3 True`  | Return `SourceText` entries for each comment.
 `docstrings`     | bool     | `#!py3 True`  | Return `SourceText` entries for each docstrings.
 `group_comments` | bool     | `#!py3 False` | Group consecutive Python comments as one `SourceText` entry.
+`decode_escapes` | bool     | `#!py3 True`  | Decode escapes and strip out format variables. Behavior is based on the string type that is encountered. This affects both docstrings and non-docstrings.
 `strings`        | string   | `#!py3 False` | Return `SourceText` entries for each string (non-docstring).
-`allowed`        | string   | `#!py3 fu`    | Specifies which string types `strings` searches: bytes (`b`), format (`f`), raw (`r`), and Unicode (`u`). 
+`allowed`        | string   | `#!py3 fu`    | Specifies which string types `strings` searches: bytes (`b`), format (`f`), raw (`r`), and Unicode (`u`). This does not affect docstrings. When `docstrings` is enabled, all docstrings are parsed.
 
 ## Categories
 

--- a/pyspelling/filters/__init__.py
+++ b/pyspelling/filters/__init__.py
@@ -33,6 +33,8 @@ RE_UTF_BOM = re.compile(
 
 RE_CATEGORY_NAME = re.compile(r'^[-a-z0-9_]+$', re.I)
 
+RE_LINE_ENDINGS = re.compile(r'(?:\r\n|(?!\r\n)[\n\r])')
+
 BINARY_ENCODE = ''
 
 
@@ -218,6 +220,11 @@ class Filter(plugin.Plugin):
             raise UnicodeDecodeError('None', b'', 0, 0, 'Unicode detection is not applied to very large files!')
 
         return encoding
+
+    def norm_nl(self, text):
+        """Normalize line endings."""
+
+        return RE_LINE_ENDINGS.sub('\n', text)
 
     def content_check(self, f):
         """File content check."""

--- a/pyspelling/filters/context.py
+++ b/pyspelling/filters/context.py
@@ -23,7 +23,8 @@ class ContextFilter(filters.Filter):
         return {
             "context_visible_first": False,
             "delimiters": [],
-            "escapes": ''
+            "escapes": '',
+            "normalize_line_endings": True
         }
 
     def validate_options(self, k, v):
@@ -50,6 +51,7 @@ class ContextFilter(filters.Filter):
         self.context_visible_first = self.config['context_visible_first']
         self.delimiters = []
         self.escapes = None
+        self.line_endings = self.config['normalize_line_endings']
         escapes = []
         for delimiter in self.config['delimiters']:
             if not isinstance(delimiter, dict):
@@ -88,6 +90,9 @@ class ContextFilter(filters.Filter):
 
     def _filter(self, text):
         """Context delimiter filter."""
+
+        if self.line_endings:
+            text = self.norm_nl(text)
 
         new_text = []
         index = 0

--- a/pyspelling/filters/cpp.py
+++ b/pyspelling/filters/cpp.py
@@ -319,6 +319,7 @@ class CppFilter(filters.Filter):
                     start = groups.get('raw')[0].lower()
                     if (
                         'r' not in self.allowed or
+                        (start == 'r' and 's' not in self.allowed) or
                         (start == 'l' and 'w' not in self.allowed) or
                         (start == 'u' and 'u' not in self.allowed)
                     ):
@@ -339,7 +340,7 @@ class CppFilter(filters.Filter):
                         value, encoding = self.evaluate_unicode(value)
                 elif self.decode_escapes and value.startswith(('"', 'L')):
                     start = value[0]
-                    if start == 'L' and 'w' not in self.allowed:
+                    if (start == 'L' and 'w' not in self.allowed) or (start != 'L' and 's' not in self.allowed):
                         value = ''
                     else:
                         # Decode normal strings.

--- a/pyspelling/filters/cpp.py
+++ b/pyspelling/filters/cpp.py
@@ -4,20 +4,37 @@ import codecs
 from .. import filters
 import textwrap
 
-RE_COMMENT = re.compile(
-    r'''(?x)
-        (?P<comments>
-            (?P<block>/\*[^*]*\*+(?:[^/*][^*]*\*+)*/) |                      # multi-line comments
-            (?P<start>^)?(?P<leading_space>[ \t]*)?(?P<line>//(?:[^\r\n])*)  # single line comments
-        ) |
-        (?P<code>
-            "(?:\\.|[^"\\])*" |                                              # double quotes
-            '(?:\\.|[^'\\])*' |                                              # single quotes
-            .[^/"']*?                                                        # everything else
-        )
-    ''',
-    re.DOTALL | re.MULTILINE
+COMMENTS = r'''(?x)
+(?P<comments>
+    (?P<block>/\*[^*]*\*+(?:[^/*][^*]*\*+)*/) |                 # multi-line comments
+    (?P<start>^)?(?P<leading_space>[ \t]*)?(?P<line>//(?:{})*)  # single line comments
+) |
+(?P<strings>
+    "(?:\\.|[^"\\])*" |                                         # double quotes
+    '(?:\\.|[^'\\])*'                                           # single quotes
+) |
+(?P<code>
+    .[^/"']*?                                                   # everything else
 )
+'''
+
+C_COMMENT = re.compile(COMMENTS.format(r'\\.|[^\\\n]+'), re.DOTALL | re.MULTILINE)
+
+GENERIC = re.compile(COMMENTS.format('[^\n]'), re.DOTALL | re.MULTILINE)
+
+TRIGRAPHS = {
+    '??=': '#',
+    '??/': '\\',
+    '??\'': '^',
+    '??(': '[',
+    '??)': ']',
+    '??!': '|',
+    '??<': '{',
+    '??>': '}',
+    '??-': '~'
+}
+
+RE_TRIGRAPHS = re.compile(r'\?{2}[=/\'()!<>-]')
 
 
 class CppFilter(filters.Filter):
@@ -26,6 +43,8 @@ class CppFilter(filters.Filter):
     def __init__(self, options, default_encoding='utf-8'):
         """Initialization."""
 
+        self.pattern = GENERIC
+        self.trigraphs = False
         super().__init__(options, default_encoding)
 
     def get_default_config(self):
@@ -35,7 +54,9 @@ class CppFilter(filters.Filter):
             "block_comments": True,
             "line_comments": True,
             "group_comments": False,
-            "prefix": 'cpp'
+            "prefix": 'cpp',
+            "generic_comments": False,
+            "trigraphs": False
         }
 
     def setup(self):
@@ -45,6 +66,11 @@ class CppFilter(filters.Filter):
         self.lines = self.config['line_comments']
         self.group_comments = self.config['group_comments']
         self.prefix = self.config['prefix']
+        self.generic_comments = self.config['generic_comments']
+        self.enable_strings = False
+        self.trigraphs = self.config['trigraphs']
+        if not self.generic_comments:
+            self.pattern = C_COMMENT
 
     def evaluate_block(self, groups):
         """Evaluate block comments."""
@@ -56,7 +82,7 @@ class CppFilter(filters.Filter):
         """Evaluate inline comments at the tail of source code."""
 
         if self.lines:
-            self.line_comments.append([groups['line'][2:], self.line_num])
+            self.line_comments.append([groups['line'][2:].replace('\n', ''), self.line_num])
 
     def evaluate_inline(self, groups):
         """Evaluate inline comments on their own lines."""
@@ -69,17 +95,23 @@ class CppFilter(filters.Filter):
                 self.line_num == self.prev_line + 1 and
                 groups['leading_space'] == self.leading
             ):
-                self.line_comments[-1][0] += '\n' + groups['line'][2:]
+                self.line_comments[-1][0] += '\n' + groups['line'][2:].replace('\n', '')
             else:
-                self.line_comments.append([groups['line'][2:], self.line_num])
+                self.line_comments.append([groups['line'][2:].replace('\n', ''), self.line_num])
             self.leading = groups['leading_space']
             self.prev_line = self.line_num
 
-    def _evaluate(self, m):
+    def evaluate_strings(self, groups):
+        """Evaluate strings."""
+
+    def evaluate(self, m):
         """Search for comments."""
 
         g = m.groupdict()
-        if g["code"]:
+        if g["strings"]:
+            self.evaluate_strings(g)
+            self.line_num += g['strings'].count('\n')
+        elif g["code"]:
             self.line_num += g["code"].count('\n')
         else:
             if g['block']:
@@ -98,7 +130,7 @@ class CppFilter(filters.Filter):
         for comment, line in text_list:
             content.append(
                 filters.SourceText(
-                    textwrap.dedent(self.norm_nl(comment)),
+                    textwrap.dedent(comment),
                     "%s (%d)" % (context, line),
                     encoding,
                     prefix + category
@@ -110,12 +142,22 @@ class CppFilter(filters.Filter):
 
         self.extend_src_text(content, context, self.block_comments, encoding, 'block-comment')
         self.extend_src_text(content, context, self.line_comments, encoding, 'line-comment')
+        if self.strings:
+            self.extend_src_text(content, context, self.strings, encoding, 'strings')
+
+    def process_trigraphs(self, m):
+        """Process trigraphs."""
+
+        return TRIGRAPHS[m.group(0)]
 
     def find_comments(self, text):
         """Find comments."""
 
-        for m in RE_COMMENT.finditer(text):
-            self._evaluate(m)
+        if self.trigraphs:
+            text = RE_TRIGRAPHS.sub(self.process_trigraphs, text)
+
+        for m in self.pattern.finditer(self.norm_nl(text)):
+            self.evaluate(m)
 
     def _filter(self, text, context, encoding):
         """Filter JavaScript comments."""
@@ -126,6 +168,7 @@ class CppFilter(filters.Filter):
         self.leading = ''
         self.block_comments = []
         self.line_comments = []
+        self.strings = []
 
         self.find_comments(text)
         self.extend_src(content, context, encoding)

--- a/pyspelling/filters/cpp.py
+++ b/pyspelling/filters/cpp.py
@@ -17,7 +17,7 @@ COMMENTS = r'''(?x)
     '(?:\\.|[^'\\])*'                                           # single quotes
 ) |
 (?P<code>
-    .[^/"'RLuU]*?                                               # everything else
+    .[^/"'{}]*?                                               # everything else
 )
 '''
 
@@ -27,9 +27,9 @@ CPP_STRING = r'''
 (?:L|u8?|U)'(?:\\.|[^'\\])*' |
 '''
 
-C_COMMENT = re.compile(COMMENTS.format(r'\\.|[^\\\n]+', CPP_STRING), re.DOTALL | re.MULTILINE)
+C_COMMENT = re.compile(COMMENTS.format(r'\\.|[^\\\n]+', CPP_STRING, 'RLuU'), re.DOTALL | re.MULTILINE)
 
-GENERIC = re.compile(COMMENTS.format('[^\n]', ''), re.DOTALL | re.MULTILINE)
+GENERIC = re.compile(COMMENTS.format('[^\n]', '', ''), re.DOTALL | re.MULTILINE)
 
 TRIGRAPHS = {
     '??=': '#',

--- a/pyspelling/filters/cpp.py
+++ b/pyspelling/filters/cpp.py
@@ -98,7 +98,7 @@ class CppFilter(filters.Filter):
         for comment, line in text_list:
             content.append(
                 filters.SourceText(
-                    textwrap.dedent(comment),
+                    textwrap.dedent(self.norm_nl(comment)),
                     "%s (%d)" % (context, line),
                     encoding,
                     prefix + category

--- a/pyspelling/filters/cpp.py
+++ b/pyspelling/filters/cpp.py
@@ -179,7 +179,7 @@ class CppFilter(filters.Filter):
                         value = ' '
             return value
 
-        return self.norm_nl(RE_ESC.sub(replace_unicode, value).replace('\x00', '\n'))
+        return self.norm_nl(RE_UESC.sub(replace_unicode, value).replace('\x00', '\n'))
 
     def evaluate_normal(self, value):
         """Evaluate normal string."""

--- a/pyspelling/filters/cpp.py
+++ b/pyspelling/filters/cpp.py
@@ -67,7 +67,7 @@ class CppFilter(filters.Filter):
         self.group_comments = self.config['group_comments']
         self.prefix = self.config['prefix']
         self.generic_comments = self.config['generic_comments']
-        self.enable_strings = False
+        self.strings = False
         self.trigraphs = self.config['trigraphs']
         if not self.generic_comments:
             self.pattern = C_COMMENT
@@ -82,7 +82,7 @@ class CppFilter(filters.Filter):
         """Evaluate inline comments at the tail of source code."""
 
         if self.lines:
-            self.line_comments.append([groups['line'][2:].replace('\n', ''), self.line_num])
+            self.line_comments.append([groups['line'][2:].replace('\\\n', ''), self.line_num])
 
     def evaluate_inline(self, groups):
         """Evaluate inline comments on their own lines."""
@@ -95,9 +95,9 @@ class CppFilter(filters.Filter):
                 self.line_num == self.prev_line + 1 and
                 groups['leading_space'] == self.leading
             ):
-                self.line_comments[-1][0] += '\n' + groups['line'][2:].replace('\n', '')
+                self.line_comments[-1][0] += '\n' + groups['line'][2:].replace('\\\n', '')
             else:
-                self.line_comments.append([groups['line'][2:].replace('\n', ''), self.line_num])
+                self.line_comments.append([groups['line'][2:].replace('\\\n', ''), self.line_num])
             self.leading = groups['leading_space']
             self.prev_line = self.line_num
 
@@ -142,8 +142,8 @@ class CppFilter(filters.Filter):
 
         self.extend_src_text(content, context, self.block_comments, encoding, 'block-comment')
         self.extend_src_text(content, context, self.line_comments, encoding, 'line-comment')
-        if self.strings:
-            self.extend_src_text(content, context, self.strings, encoding, 'strings')
+        if self.quoted_strings:
+            self.extend_src_text(content, context, self.quoted_strings, encoding, 'strings')
 
     def process_trigraphs(self, m):
         """Process trigraphs."""
@@ -168,7 +168,7 @@ class CppFilter(filters.Filter):
         self.leading = ''
         self.block_comments = []
         self.line_comments = []
-        self.strings = []
+        self.quoted_strings = []
 
         self.find_comments(text)
         self.extend_src(content, context, encoding)

--- a/pyspelling/filters/javascript.py
+++ b/pyspelling/filters/javascript.py
@@ -106,7 +106,7 @@ class JavaScriptFilter(cpp.CppFilter):
                 )
             else:
                 value = groups['strings'][1:-1]
-            self.quoted_strings.append([value, self.line_num])
+            self.quoted_strings.append([value, self.line_num, 'utf-8'])
 
     def evaluate_block(self, groups):
         """Evaluate block comments."""
@@ -118,19 +118,19 @@ class JavaScriptFilter(cpp.CppFilter):
                 for line in m1.group(1).splitlines(True):
                     l = line.lstrip()
                     lines.append(l[1:] if l.startswith('*') else l)
-                self.jsdoc_comments.append([''.join(lines), self.line_num])
+                self.jsdoc_comments.append([''.join(lines), self.line_num, self.current_encoding])
             elif self.blocks:
-                self.block_comments.append([groups['block'][2:-2], self.line_num])
+                self.block_comments.append([groups['block'][2:-2], self.line_num, self.current_encoding])
         elif self.blocks:
-            self.block_comments.append([groups['block'][2:-2], self.line_num])
+            self.block_comments.append([groups['block'][2:-2], self.line_num, self.current_encoding])
 
-    def extend_src(self, content, context, encoding):
+    def extend_src(self, content, context):
         """Extend source list."""
 
-        self.extend_src_text(content, context, self.block_comments, encoding, 'block-comment')
-        self.extend_src_text(content, context, self.line_comments, encoding, 'line-comment')
-        self.extend_src_text(content, context, self.jsdoc_comments, encoding, 'docs')
-        self.extend_src_text(content, context, self.quoted_strings, 'utf-8', 'strings')
+        self.extend_src_text(content, context, self.block_comments, 'block-comment')
+        self.extend_src_text(content, context, self.line_comments, 'line-comment')
+        self.extend_src_text(content, context, self.jsdoc_comments, 'docs')
+        self.extend_src_text(content, context, self.quoted_strings, 'strings')
 
     def _filter(self, text, context, encoding):
         """Filter JavaScript comments."""

--- a/pyspelling/filters/javascript.py
+++ b/pyspelling/filters/javascript.py
@@ -130,7 +130,7 @@ class JavaScriptFilter(cpp.CppFilter):
         self.extend_src_text(content, context, self.block_comments, encoding, 'block-comment')
         self.extend_src_text(content, context, self.line_comments, encoding, 'line-comment')
         self.extend_src_text(content, context, self.jsdoc_comments, encoding, 'docs')
-        self.extend_src_text(content, context, self.quoted_strings, encoding, 'strings')
+        self.extend_src_text(content, context, self.quoted_strings, 'utf-8', 'strings')
 
     def _filter(self, text, context, encoding):
         """Filter JavaScript comments."""

--- a/pyspelling/filters/javascript.py
+++ b/pyspelling/filters/javascript.py
@@ -87,7 +87,7 @@ class JavaScriptFilter(cpp.CppFilter):
             value = chr(value) + overflow
         elif('other'):
             value = esc[1:]
-        return value
+        return value.replace('\x00', '\n')
 
     def replace_surrogates(self, m):
         """Replace surrogates."""

--- a/pyspelling/filters/javascript.py
+++ b/pyspelling/filters/javascript.py
@@ -130,6 +130,7 @@ class JavaScriptFilter(cpp.CppFilter):
         self.extend_src_text(content, context, self.block_comments, encoding, 'block-comment')
         self.extend_src_text(content, context, self.line_comments, encoding, 'line-comment')
         self.extend_src_text(content, context, self.jsdoc_comments, encoding, 'docs')
+        self.extend_src_text(content, context, self.quoted_strings, encoding, 'strings')
 
     def _filter(self, text, context, encoding):
         """Filter JavaScript comments."""

--- a/pyspelling/filters/python.py
+++ b/pyspelling/filters/python.py
@@ -31,12 +31,14 @@ BACK_SLASH_TRANSLATION = {
     "\\n": '\n',
     "\\v": '\v',
     "\\\\": '\\',
+    '\\"': '"',
+    "\\'": "'",
     "\n": ''
 }
 
 RE_ESC = re.compile(
     r'''(?x)
-    (?P<special>\\[abfrtnv\\\n])|
+    (?P<special>\\['"abfrtnv\\\n])|
     (?P<char>\\U[\da-fA-F]{8}|\\u[\da-fA-F]{4}|\\x[\da-fA-F]{2})|
     (?P<oct>\\[0-7]{1,3})|
     (?P<name>\\N\{[^}{]*\})
@@ -45,7 +47,7 @@ RE_ESC = re.compile(
 
 RE_BESC = re.compile(
     r'''(?x)
-    (?P<special>\\[abfrtnv\\\n])|
+    (?P<special>\\['"abfrtnv\\\n])|
     (?P<char>\\x[\da-fA-F]{2})|
     (?P<oct>\\[0-7]{1,3})
     '''
@@ -53,7 +55,7 @@ RE_BESC = re.compile(
 
 RE_FESC = re.compile(
     r'''(?x)
-    (?P<special>\\[abfrtnv\\\n])|
+    (?P<special>\\['"abfrtnv\\\n])|
     (?P<char>\\U[\da-fA-F]{8}|\\u[\da-fA-F]{4}|\\x[\da-fA-F]{2})|
     (?P<oct>\\[0-7]{1,3})|
     (?P<name>\\N\{\{[^}{]*\}\})|

--- a/pyspelling/filters/python.py
+++ b/pyspelling/filters/python.py
@@ -102,7 +102,8 @@ class PythonFilter(filters.Filter):
             'docstrings': True,
             'strings': False,
             'group_comments': False,
-            'allowed': 'fu'
+            'allowed': 'fu',
+            'decode_escapes': True
         }
 
     def setup(self):
@@ -113,6 +114,7 @@ class PythonFilter(filters.Filter):
         self.strings = self.config['strings']
         self.group_comments = self.config['group_comments']
         self.allowed = self.eval_string_type(self.config['allowed'])
+        self.decode_escapes = self.config['decode_escapes']
 
     def validate_options(self, k, v):
         """Validate options."""
@@ -201,10 +203,10 @@ class PythonFilter(filters.Filter):
         is_raw = 'r' in stype
         is_format = 'f' in stype
         content = m.group(3)
-        if is_raw and is_format:
-            string = self.norm_nl(FE_RFESC.sub(self.replace_unicode, content))
-        elif is_raw:
+        if is_raw and (not is_format or not self.decode_escapes):
             string = self.norm_nl(content)
+        elif is_raw and is_format:
+            string = self.norm_nl(FE_RFESC.sub(self.replace_unicode, content))
         elif is_bytes:
             string = self.norm_nl(RE_BESC.sub(self.replace_bytes, content))
         elif is_format:

--- a/pyspelling/filters/python.py
+++ b/pyspelling/filters/python.py
@@ -215,7 +215,7 @@ class PythonFilter(filters.Filter):
         else:
             string = self.norm_nl(RE_ESC.sub(self.replace_unicode, content))
 
-        return textwrap.dedent(RE_NON_PRINTABLE.sub(' ', string) if is_bytes else string), is_bytes
+        return textwrap.dedent(RE_NON_PRINTABLE.sub('\n', string) if is_bytes else string), is_bytes
 
     def _filter(self, text, context, encoding):
         """Retrieve the Python docstrings."""

--- a/pyspelling/filters/python.py
+++ b/pyspelling/filters/python.py
@@ -193,12 +193,12 @@ class PythonFilter(filters.Filter):
             value = chr(value)
         return value.replace('\x00', '\n')
 
-    def process_strings(self, string):
+    def process_strings(self, string, docstrings=False):
         """Process escapes."""
 
         m = RE_STRING_TYPE.match(string)
         stype = self.eval_string_type(m.group(1) if m.group(1) else '')
-        if stype - self.allowed:
+        if stype - self.allowed and not docstrings:
             return '', False
         is_bytes = 'b' in stype
         is_raw = 'r' in stype
@@ -289,7 +289,7 @@ class PythonFilter(filters.Filter):
                         value = value.strip()
                         if possible_fmt_str and value.startswith(("'", "\"")):
                             value = possible_fmt_str[1] + value
-                        string, is_bytes = self.process_strings(value)
+                        string, is_bytes = self.process_strings(value, docstrings=True)
                         if string:
                             loc = "%s(%s): %s" % (stack[0][0], line, ''.join([crumb[0] for crumb in stack[1:]]))
                             docstrings.append(

--- a/pyspelling/filters/python.py
+++ b/pyspelling/filters/python.py
@@ -121,6 +121,7 @@ class PythonFilter(filters.Filter):
     def validate_options(self, k, v):
         """Validate options."""
 
+        super().validate_options(k, v)
         if k == 'allowed':
             for c in v.lower():
                 if c not in 'rbuf':

--- a/pyspelling/filters/python.py
+++ b/pyspelling/filters/python.py
@@ -18,8 +18,6 @@ PREV_DOC_TOKENS = (tokenize.INDENT, tokenize.DEDENT, tokenize.NEWLINE, tokenize.
 RE_PY_ENCODE = re.compile(
     br'^[^\r\n]*?coding[:=]\s*([-\w.]+)|[^\r\n]*?\r?\n[^\r\n]*?coding[:=]\s*([-\w.]+)'
 )
-RE_NON_PRINTABLE_ASCII = re.compile(br"[^ -~]+")
-
 
 BACK_SLASH_TRANSLATION = {
     "\\a": '\a',
@@ -34,29 +32,43 @@ BACK_SLASH_TRANSLATION = {
 }
 
 RE_ESC = re.compile(
-    r'''(\\[abfrtnv\\\n])|(\\U[\da-fA-F]{8}|\\u[\da-fA-F]{4}|\\x[\da-fA-F]{2})|(\\[0-7]{1,3})|(\N\{[^}{]*\})'''
+    r'''(?x)
+    (?P<special>\\[abfrtnv\\\n])|
+    (?P<char>\\U[\da-fA-F]{8}|\\u[\da-fA-F]{4}|\\x[\da-fA-F]{2})|
+    (?P<oct>\\[0-7]{1,3})|
+    (?P<name>\\N\{[^}{]*\})
+    '''
 )
 
 RE_BESC = re.compile(
-    r'''(\\[abfrtnv\\\n])|(\\x[\da-fA-F]{2})|(\\[0-7]{1,3})'''
+    r'''(?x)
+    (?P<special>\\[abfrtnv\\\n])|
+    (?P<char>\\x[\da-fA-F]{2})|
+    (?P<oct>\\[0-7]{1,3})
+    '''
 )
 
 RE_FESC = re.compile(
     r'''(?x)
-    (\\[abfrtnv\\\n])|
-    (\\U[\da-fA-F]{8}|\\u[\da-fA-F]{4}|\\x[\da-fA-F]{2})|
-    (\\[0-7]{1,3})|
-    (\N\{\{[^}{]*\}\})|
-    (\{\{)|
-    (\{[^}{]*\})
+    (?P<special>\\[abfrtnv\\\n])|
+    (?P<char>\\U[\da-fA-F]{8}|\\u[\da-fA-F]{4}|\\x[\da-fA-F]{2})|
+    (?P<oct>\\[0-7]{1,3})|
+    (?P<name>\\N\{\{[^}{]*\}\})|
+    (?P<fesc>\{\{)|
+    (?P<format>\{[^}{]*\})
     '''
 )
 
-RE_FBESC = re.compile(
-    r'''(\\[abfrtnv\\\n])|(\\x[\da-fA-F]{2})|(\\[0-7]{1,3})(\{\{|\}\})|(\{[^}{]*\})'''
+FE_RFESC = re.compile(
+    r'''(?x)
+    (?P<fesc>\{\{)|
+    (?P<format>\{[^}{]*\})
+    '''
 )
 
 RE_STRING_TYPE = re.compile(r'''((?:r|u|f|b)+)?(\'''|"""|'|")(.*?)\2''', re.I | re.S)
+
+RE_NON_PRINTABLE = re.compile(r'[\x00-\x0f\x0b-\x1f\x7f-\xff]+')
 
 
 class PythonFilter(filters.Filter):
@@ -78,83 +90,9 @@ class PythonFilter(filters.Filter):
             'comments': True,
             'docstrings': True,
             'strings': False,
-            'group_comments': False
+            'group_comments': False,
+            'allowed': 'u,f'
         }
-
-    def replace_escapes(self, m):
-        """Replace escapes."""
-
-        esc = m.group(0)
-        if m.group(1):
-            return BACK_SLASH_TRANSLATION[esc]
-        elif m.group(2):
-            try:
-                esc = chr(int(esc[2:], 16))
-            except:
-                pass
-            return esc
-        elif m.group(3):
-            value = int(esc[1:], 8)
-            return chr(value)
-        elif m.group(4):
-            try:
-                esc = unicodedata.lookup(esc[3:-1])
-            except:
-                pass
-            return esc
-
-    def replace_format_escapes(self, m):
-        """Replace format escapes."""
-
-        if m.group(5):
-            return m.group(0)
-        elif m.group(6):
-            return ' '
-        return replace_escapes(m)
-
-    def replace_format_byte_escapes(self, m):
-        """Replace escapes."""
-
-        if m.group(5):
-            return m.group(0)
-        elif m.group(6):
-            return ' '
-        return replace_byte_escapes(m)
-
-    def replace_byte_escapes(self, m):
-        """Replace escapes."""
-
-        esc = m.group(0)
-        if m.group(1):
-            return BACK_SLASH_TRANSLATION[esc]
-        elif m.group(2):
-            try:
-                esc = chr(int(esc[2:], 16))
-            except:
-                pass
-            return esc
-        elif m.group(3):
-            value = int(esc[1:], 8)
-            if value > 255:
-                value -= 256
-            return chr(value)
-
-    def process_escapes(self, string):
-        """Process escapes."""
-
-        m = RE_STRING_TYPE.match(self.norm_nl(string))
-        stype = m.group(1).lower() if m.group(1) else ''
-        content = m.group(3)
-        if 'r' in stype:
-            return content
-        if 'b' in stype:
-            if 'f' in stype:
-                RE_FBESC.sub(self.replace_format_byte_escapes, content)
-            else:
-                return RE_BESC.sub(self.replace_byte_escapes, content)
-        if 'f' in stype:
-            return RE_FESC.sub(self.replace_format_escapes, content)
-        return RE_ESC.sub(self.replace_escapes, content)
 
     def setup(self):
         """Setup."""
@@ -163,6 +101,18 @@ class PythonFilter(filters.Filter):
         self.docstrings = self.config['docstrings']
         self.strings = self.config['strings']
         self.group_comments = self.config['group_comments']
+        self.allowed = set()
+        for item in self.config['allowed'].split(','):
+            self.allowed.add(self.eval_string_type(item))
+
+    def validate_options(self, k, v):
+        """Validate options."""
+
+        if k == 'allowed':
+            for item in v.split(','):
+                for c in item:
+                    if c.lower() not in 'rbuf':
+                        raise ValueError("{}: '{}' is not a valid string type".format(self.__class__.__name__, c))
 
     def header_check(self, content):
         """Special Python encoding check."""
@@ -179,10 +129,79 @@ class PythonFilter(filters.Filter):
             encode = 'utf-8'
         return encode
 
-    def get_ascii(self, text):
-        """Retrieve ASCII text from byte string."""
+    def eval_string_type(self, stype):
+        """Evaluate string type."""
 
-        return RE_NON_PRINTABLE_ASCII.sub(r' ', text).decode('ascii')
+        return tuple(sorted(set([c.lower() for c in stype if c.lower() != 'u'])))
+
+    def replace_unicode(self, m):
+        """Replace escapes."""
+
+        groups = m.groupdict()
+        esc = m.group(0)
+        if groups.get('fesc'):
+            return m.group(0)
+        elif groups.get('format'):
+            return ' '
+        elif groups.get('special'):
+            return BACK_SLASH_TRANSLATION[esc]
+        elif groups.get('char'):
+            try:
+                esc = chr(int(esc[2:], 16))
+            except Exception:
+                pass
+            return esc
+        elif groups.get('oct'):
+            value = int(esc[1:], 8)
+            return chr(value)
+        elif groups.get('named'):
+            try:
+                esc = unicodedata.lookup(esc[3:-1])
+            except Exception:
+                pass
+            return esc
+
+    def replace_bytes(self, m):
+        """Replace escapes."""
+
+        esc = m.group(0)
+        if m.group('special'):
+            return BACK_SLASH_TRANSLATION[esc]
+        elif m.group('char'):
+            try:
+                esc = chr(int(esc[2:], 16))
+            except Exception:
+                pass
+            return esc
+        elif m.group('oct'):
+            value = int(esc[1:], 8)
+            if value > 255:
+                value -= 256
+            return chr(value)
+
+    def process_strings(self, string):
+        """Process escapes."""
+
+        m = RE_STRING_TYPE.match(string)
+        stype = self.eval_string_type(m.group(1) if m.group(1) else '')
+        if stype not in self.allowed:
+            return '', False
+        is_bytes = 'b' in stype
+        is_raw = 'r' in stype
+        is_format = 'f' in stype
+        content = m.group(3)
+        if is_raw and is_format:
+            string = self.norm_nl(FE_RFESC.sub(self.replace_unicode, content))
+        elif is_raw:
+            string = self.norm_nl(content)
+        elif is_bytes:
+            string = self.norm_nl(RE_BESC.sub(self.replace_bytes, content))
+        elif is_format:
+            string = self.norm_nl(RE_FESC.sub(self.replace_unicode, content))
+        else:
+            string = self.norm_nl(RE_ESC.sub(self.replace_unicode, content))
+
+        return textwrap.dedent(RE_NON_PRINTABLE.sub(' ', string) if is_bytes else string), is_bytes
 
     def _filter(self, text, context, encoding):
         """Retrieve the Python docstrings."""
@@ -245,14 +264,18 @@ class PythonFilter(filters.Filter):
                 if prev_token_type in PREV_DOC_TOKENS:
                     if self.docstrings:
                         value = value.strip()
-                        string = textwrap.dedent(self.process_escapes(value))
-                        loc = "%s(%s): %s" % (stack[0][0], line, ''.join([crumb[0] for crumb in stack[1:]]))
-                        docstrings.append(filters.SourceText(string, loc, encoding, 'py-docstring'))
+                        string, is_bytes = self.process_strings(value)
+                        if string:
+                            loc = "%s(%s): %s" % (stack[0][0], line, ''.join([crumb[0] for crumb in stack[1:]]))
+                            docstrings.append(
+                                filters.SourceText(string, loc, 'ascii' if is_bytes else encoding, 'py-docstring')
+                            )
                 elif self.strings:
                     value = value.strip()
-                    string = textwrap.dedent(self.process_escapes(value))
-                    loc = "%s(%s): %s" % (stack[0][0], line, ''.join([crumb[0] for crumb in stack[1:]]))
-                    strings.append(filters.SourceText(string, loc, encoding, 'py-string'))
+                    string, is_bytes = self.process_strings(value)
+                    if string:
+                        loc = "%s(%s): %s" % (stack[0][0], line, ''.join([crumb[0] for crumb in stack[1:]]))
+                        strings.append(filters.SourceText(string, loc, 'ascii' if is_bytes else encoding, 'py-string'))
 
             if token_type == tokenize.INDENT:
                 indent = value

--- a/pyspelling/filters/python.py
+++ b/pyspelling/filters/python.py
@@ -73,7 +73,7 @@ FE_RFESC = re.compile(
 
 RE_STRING_TYPE = re.compile(r'''((?:r|u|f|b)+)?(\'''|"""|'|")(.*?)\2''', re.I | re.S)
 
-RE_NON_PRINTABLE = re.compile(r'[\x00-\x0f\x0b-\x1f\x7f-\xff]+')
+RE_NON_PRINTABLE = re.compile(r'[\x00-\x09\x0b-\x1f\x7f-\xff]+')
 
 FMT_STR = (
     'f', 'F',
@@ -172,12 +172,13 @@ class PythonFilter(filters.Filter):
                 value = unicodedata.lookup(esc[3:-1])
             except Exception:
                 value = esc
-        return value.replace('\x00', ' ')
+        return value.replace('\x00', '\n')
 
     def replace_bytes(self, m):
         """Replace escapes."""
 
         esc = m.group(0)
+        value = esc
         if m.group('special'):
             value = BACK_SLASH_TRANSLATION[esc]
         elif m.group('char'):
@@ -291,20 +292,17 @@ class PythonFilter(filters.Filter):
                         string, is_bytes = self.process_strings(value)
                         if string:
                             loc = "%s(%s): %s" % (stack[0][0], line, ''.join([crumb[0] for crumb in stack[1:]]))
-                            print(string)
                             docstrings.append(
-                                filters.SourceText(string, loc, 'ascii' if is_bytes else encoding, 'py-docstring')
+                                filters.SourceText(string, loc, 'utf-8', 'py-docstring')
                             )
                 elif self.strings:
                     value = value.strip()
                     if possible_fmt_str and value.startswith(("'", "\"")):
                         value = possible_fmt_str[1] + value
                     string, is_bytes = self.process_strings(value)
-                    print('======')
-                    print(string, is_bytes)
                     if string:
                         loc = "%s(%s): %s" % (stack[0][0], line, ''.join([crumb[0] for crumb in stack[1:]]))
-                        strings.append(filters.SourceText(string, loc, 'ascii' if is_bytes else encoding, 'py-string'))
+                        strings.append(filters.SourceText(string, loc, 'utf-8', 'py-string'))
 
             if token_type == tokenize.INDENT:
                 indent = value

--- a/pyspelling/filters/python.py
+++ b/pyspelling/filters/python.py
@@ -172,7 +172,7 @@ class PythonFilter(filters.Filter):
                 value = unicodedata.lookup(esc[3:-1])
             except Exception:
                 value = esc
-        return value
+        return value.replace('\x00', ' ')
 
     def replace_bytes(self, m):
         """Replace escapes."""
@@ -190,7 +190,7 @@ class PythonFilter(filters.Filter):
             if value > 255:
                 value -= 256
             value = chr(value)
-        return value
+        return value.replace('\x00', '\n')
 
     def process_strings(self, string):
         """Process escapes."""

--- a/pyspelling/filters/stylesheets.py
+++ b/pyspelling/filters/stylesheets.py
@@ -77,12 +77,11 @@ class StylesheetsFilter(cpp.CppFilter):
         else:
             super().evaluate(m)
 
-    def extend_src(self, content, context, encoding):
+    def extend_src(self, content, context):
         """Extend source list."""
 
-        self.extend_src_text(content, context, self.block_comments, encoding, 'block-comment')
-        if self.stylesheets != CSS:
-            self.extend_src_text(content, context, self.line_comments, encoding, 'line-comment')
+        self.extend_src_text(content, context, self.block_comments, 'block-comment')
+        self.extend_src_text(content, context, self.line_comments, 'line-comment')
 
 
 def get_plugin():

--- a/pyspelling/filters/stylesheets.py
+++ b/pyspelling/filters/stylesheets.py
@@ -61,25 +61,21 @@ class StylesheetsFilter(cpp.CppFilter):
         # If the style isn't found, just go with CSS, then use the appropriate prefix.
         self.stylesheets = STYLESHEET_TYPE.get(self.config['stylesheets'].lower(), CSS)
         self.prefix = [k for k, v in STYLESHEET_TYPE.items() if v == SASS][0]
-
-    def find_comments(self, text):
-        """Find comments."""
-
         if self.stylesheets == CSS:
-            for m in RE_CSS_COMMENT.finditer(text):
-                self._css_evaluate(m)
-        else:
-            super().find_comments(text)
+            self.pattern = RE_CSS_COMMENT
 
-    def _css_evaluate(self, m):
+    def evaluate(self, m):
         """Search for comments."""
 
-        g = m.groupdict()
-        if g["code"]:
-            self.line_num += g["code"].count('\n')
+        if self.stylesheets == CSS:
+            g = m.groupdict()
+            if g["code"]:
+                self.line_num += g["code"].count('\n')
+            else:
+                self.evaluate_block(g)
+                self.line_num += g['comments'].count('\n')
         else:
-            self.evaluate_block(g)
-            self.line_num += g['comments'].count('\n')
+            super().evaluate(m)
 
     def extend_src(self, content, context, encoding):
         """Extend source list."""

--- a/tests/filters/test_cpp.py
+++ b/tests/filters/test_cpp.py
@@ -21,6 +21,7 @@ class TestCPP(util.PluginTestCase):
               pipeline:
               - pyspelling.filters.cpp:
                   group_comments: true
+                  trigraphs: true
             """
         ).format(self.tempdir)
         self.mktemp('.cpp.yml', config, 'utf-8')
@@ -41,8 +42,12 @@ class TestCPP(util.PluginTestCase):
             uint8_t func() {{
                 uint8_t tsdd = 3;
                 // {}
-                // {}
+                // {} \
                 reurn tsdd;
+
+                uint32_t trigraph_test = (CONSTANT_1 ??' ADKASLD) ??' CONSTANT_2;
+
+                rtuern ddst;
             }}
             """
         ).format(
@@ -50,6 +55,66 @@ class TestCPP(util.PluginTestCase):
             ' '.join(bad_comments + good_words),
             ' '.join(bad_comments2 + good_words)
         )
+
+        # Capture comment continuation
+        bad_words.extend(['reurn', 'tsdd'])
+        self.mktemp('test.txt', template, 'utf-8')
+        self.assert_spellcheck('.cpp.yml', bad_words)
+
+
+class TestCPPGeneric(util.PluginTestCase):
+    """Test CPP plugin."""
+
+    def setup_fs(self):
+        """Setup file system."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: cpp
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.cpp:
+                  group_comments: true
+                  generic_comments: true
+            """
+        ).format(self.tempdir)
+        self.mktemp('.cpp.yml', config, 'utf-8')
+
+    def test_cpp(self):
+        """Test CPP."""
+
+        bad_block = ['helo', 'begn']
+        bad_comments = ['flga', 'graet']
+        bad_comments2 = ['recieve', 'teh']
+        bad_words = bad_block + bad_comments + bad_comments2
+        good_words = ['yes', 'word']
+        template = self.dedent(
+            r"""
+            /*
+            {}
+            */
+            uint8_t func() {{
+                uint8_t tsdd = 3;
+                // {}
+                // {} \
+                reurn tsdd;
+
+                rtuern ddst;
+            }}
+            """
+        ).format(
+            '\n'.join(bad_block + good_words),
+            ' '.join(bad_comments + good_words),
+            ' '.join(bad_comments2 + good_words)
+        )
+
+        # Capture comment continuation
         self.mktemp('test.txt', template, 'utf-8')
         self.assert_spellcheck('.cpp.yml', bad_words)
 

--- a/tests/filters/test_cpp.py
+++ b/tests/filters/test_cpp.py
@@ -62,6 +62,86 @@ class TestCPP(util.PluginTestCase):
         self.assert_spellcheck('.cpp.yml', bad_words)
 
 
+class TestCPPStrings(util.PluginTestCase):
+    """Test CPP plugin."""
+
+    def setup_fs(self):
+        """Setup file system."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: cpp
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.cpp:
+                  strings: true
+                  line_comments: false
+                  group_comments: true
+            """
+        ).format(self.tempdir)
+        self.mktemp('.cpp.yml', config, 'utf-8')
+
+    def test_cpp_strings(self):
+        """Test CPP strings."""
+
+        bad_char = ['helo', 'begn']
+        bad_wchar = ['flga', 'graet']
+        bad_u8 = ['recieve', 'teh']
+        bad_u16 = ['acept', 'thruogh']
+        bad_u32 = ['hpoe', 'lvoe']
+        bad_raw = ['aaaa', 'bbbb']
+        bad_raw_delim = ['cccc', 'dddd']
+        bad_raw_wide = ['eeee', 'ffff']
+        bad_raw_u8 = ['gggg', 'hhhh']
+        bad_raw_u16 = ['iiii', 'jjjj']
+        bad_raw_u32 = ['kkkk', 'llll']
+
+        bad_words = (
+            bad_char + bad_wchar + bad_u8 + bad_u16 + bad_u32 + bad_raw + bad_raw_wide +
+            bad_raw_delim + bad_raw_u8 + bad_raw_u16 + bad_raw_u32
+        )
+        good_words = ['yes', 'word']
+        template = self.dedent(
+            r"""
+            uint8_t func() {{
+                auto c0 =   'xxxx'; // char
+                auto s0 =   "{}"; // char
+                auto s1 =  L"{}"; // wchar_t
+                auto s2 = u8"{}"; // char
+                auto s3 =  u"{}"; // char16_t
+                auto s4 =  U"{}"; // char32_t
+                auto R0 =   R"("{}")"; // const char*
+                auto R1 =   R"delim("{}")delim";    // const char*
+                auto R3 =  LR"("{}")"; // const wchar_t*
+                auto R4 = u8R"("{}")"; // const char*, encoded as UTF-8
+                auto R5 =  uR"("{}")"; // const char16_t*, encoded as UTF-16
+                auto R6 =  UR"("{}")"; // const char32_t*, encoded as UTF-32
+            }}
+            """
+        ).format(
+            ' '.join(bad_char + good_words),
+            ' '.join(bad_wchar + good_words),
+            ' '.join(bad_u8 + good_words),
+            ' '.join(bad_u16 + good_words),
+            ' '.join(bad_u32 + good_words),
+            ' '.join(bad_raw + good_words),
+            ' '.join(bad_raw_delim + good_words),
+            ' '.join(bad_raw_wide + good_words),
+            ' '.join(bad_raw_u8 + good_words),
+            ' '.join(bad_raw_u16 + good_words),
+            ' '.join(bad_raw_u32 + good_words)
+        )
+
+        self.mktemp('test.txt', template, 'utf-8')
+        self.assert_spellcheck('.cpp.yml', bad_words)
+
+
 class TestCPPGeneric(util.PluginTestCase):
     """Test CPP plugin."""
 

--- a/tests/filters/test_cpp.py
+++ b/tests/filters/test_cpp.py
@@ -83,6 +83,7 @@ class TestCPPStrings(util.PluginTestCase):
                   strings: true
                   line_comments: false
                   group_comments: true
+                  allowed: ruws
             """
         ).format(self.tempdir)
         self.mktemp('.cpp.yml', config, 'utf-8')
@@ -196,7 +197,7 @@ class TestCPPGeneric(util.PluginTestCase):
               pipeline:
               - pyspelling.filters.cpp:
                   group_comments: true
-                  generic_comments: true
+                  generic_mode: true
             """
         ).format(self.tempdir)
         self.mktemp('.cpp.yml', config, 'utf-8')

--- a/tests/filters/test_cpp.py
+++ b/tests/filters/test_cpp.py
@@ -147,9 +147,9 @@ class TestCPPStrings(util.PluginTestCase):
         template = self.dedent(
             r"""
             uint8_t func() {{
-                auto s0 =   "\xaagggg \ntext\
-                             \uaaaa \\ubbbb"; // char
-                auto s1 =  L"\xaahhhh \ntext"; // wchar_t
+                auto s0 =   "\x61gggg \ntext\
+                             \u0061yyyy \\ubbbb"; // char
+                auto s1 =  L"\x0061hhhh \ntexts"; // wchar_t
                 auto s2 = u8"\141\x000000061\u0061\U00000061"; // char
                 auto s3 =  u"\142\x000000062\u0062\U00000062"; // char16_t
                 auto s4 =  U"\143\x000000063\u0063\U00000063"; // char32_t
@@ -168,7 +168,7 @@ class TestCPPStrings(util.PluginTestCase):
         # Unicode strings will have all escapes decoded.
         # Raw will decode none.
         bad_words = [
-            'gggg', 'hhhh', 'aaaa', 'bbbb', 'cccc',
+            'agggg', 'ahhhh', 'ayyyy', 'aaaa', 'bbbb', 'cccc',
             'xaa', 'xbb', 'xcc', 'xdd', 'xee', 'xff',
             'ubbbb', 'nbad', 'vbad'
         ]

--- a/tests/filters/test_cpp.py
+++ b/tests/filters/test_cpp.py
@@ -141,6 +141,41 @@ class TestCPPStrings(util.PluginTestCase):
         self.mktemp('test.txt', template, 'utf-8')
         self.assert_spellcheck('.cpp.yml', bad_words)
 
+    def test_cpp_strings_escapes(self):
+        """Test CPP strings escapes."""
+
+        template = self.dedent(
+            r"""
+            uint8_t func() {{
+                auto s0 =   "\xaagggg \ntext\
+                             \uaaaa \\ubbbb"; // char
+                auto s1 =  L"\xaahhhh \ntext"; // wchar_t
+                auto s2 = u8"\141\x000000061\u0061\U00000061"; // char
+                auto s3 =  u"\142\x000000062\u0062\U00000062"; // char16_t
+                auto s4 =  U"\143\x000000063\u0063\U00000063"; // char32_t
+                auto R0 =   R"("\xaa \nbad")"; // const char*
+                auto R1 =   R"delim("\xbb
+                                     \vbad")delim";    // const char*
+                auto R3 =  LR"("\xcc")"; // const wchar_t*
+                auto R4 = u8R"("\xdd")"; // const char*, encoded as UTF-8
+                auto R5 =  uR"("\xee")"; // const char16_t*, encoded as UTF-16
+                auto R6 =  UR"("\xff")"; // const char32_t*, encoded as UTF-32
+            }}
+            """
+        )
+
+        # `char*` and `wchar*` will have escapes `\x`, `\u`, and `\U` stripped out as we don't know the encoding.
+        # Unicode strings will have all escapes decoded.
+        # Raw will decode none.
+        bad_words = [
+            'gggg', 'hhhh', 'aaaa', 'bbbb', 'cccc',
+            'xaa', 'xbb', 'xcc', 'xdd', 'xee', 'xff',
+            'ubbbb', 'nbad', 'vbad'
+        ]
+
+        self.mktemp('test.txt', template, 'utf-8')
+        self.assert_spellcheck('.cpp.yml', bad_words)
+
 
 class TestCPPGeneric(util.PluginTestCase):
     """Test CPP plugin."""

--- a/tests/filters/test_javascript.py
+++ b/tests/filters/test_javascript.py
@@ -58,6 +58,57 @@ class TestJavaScript(util.PluginTestCase):
         self.assert_spellcheck('.javascript.yml', bad_words)
 
 
+class TestJavaScriptStrings(util.PluginTestCase):
+    """Test JavaScript plugin."""
+
+    def setup_fs(self):
+        """Setup file system."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: javascript
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.javascript:
+                  jsdocs: true
+                  strings: true
+                  group_comments: true
+            """
+        ).format(self.tempdir)
+        self.mktemp('.javascript.yml', config, 'utf-8')
+
+    def test_javascript_strings(self):
+        """Test CPP."""
+
+        bad_string1 = ['helo', 'begn']
+        bad_string2 = ['adn', 'highight']
+        bad_words = bad_string1 + bad_string2
+        good_words = ['yes', 'word']
+        template = self.dedent(
+            r"""
+            function Func(arg, arg2) {{
+
+              test = "{} \
+              {}"
+
+              test2 = "\141\x61\u0061\u{{00000061}}\a"
+            }}
+            """
+        ).format(
+            ' '.join(bad_string1 + good_words),
+            ' '.join(bad_string2 + good_words)
+        )
+        bad_words.append('aaaaa')
+        self.mktemp('test.txt', template, 'utf-8')
+        self.assert_spellcheck('.javascript.yml', bad_words)
+
+
 class TestJavaScriptChained(util.PluginTestCase):
     """Test chained JavaScript plugin."""
 

--- a/tests/filters/test_python.py
+++ b/tests/filters/test_python.py
@@ -1,8 +1,5 @@
 """Test Python plugin."""
 from .. import util
-import sys
-
-F_SUPPORT = (3, 6) <= sys.version_info
 
 
 class TestPython(util.PluginTestCase):
@@ -162,8 +159,6 @@ class TestPythonStrings(util.PluginTestCase):
             ' '.join(bad_words + good_words)
         )
 
-        if not F_SUPPORT:
-            bad_words.append('aaaa')
         self.mktemp('test.txt', template, 'utf-8')
         self.assert_spellcheck('.pystrings.yml', bad_words)
 
@@ -182,15 +177,7 @@ class TestPythonStrings(util.PluginTestCase):
             ' '.join(bad_words + good_words)
         )
 
-        if not F_SUPPORT:
-            # Python versions that don't support format strings
-            # will not see the `fr` which will cause it to be treated
-            # like a normal Unicode string. `aaaa` should be found, but
-            # `\t` will be turned to a tab.
-            bad_words.append('aaaa')
-        else:
-            # Raw will not process `\t`. Format will strip out `aaaa`.
-            bad_words.append('tthe')
+        bad_words.append('tthe')
 
         self.mktemp('test.txt', template, 'utf-8')
         self.assert_spellcheck('.pystrings.yml', bad_words)

--- a/tests/filters/test_python.py
+++ b/tests/filters/test_python.py
@@ -76,8 +76,26 @@ class TestPythonStrings(util.PluginTestCase):
         ).format(self.tempdir)
         self.mktemp('.pystrings.yml', config, 'utf-8')
 
+    def test_python_continue(self):
+        """Test strings with line continuation."""
+
+        bad_words = ['helo', 'begn']
+        good_words = ['yes', 'word']
+        template = self.dedent(
+            r"""
+            def function():
+                test = "{} \tthe\
+                aaaa"
+            """
+        ).format(
+            ' '.join(bad_words + good_words)
+        )
+        bad_words.append('aaaa')
+        self.mktemp('test.txt', template, 'utf-8')
+        self.assert_spellcheck('.pystrings.yml', bad_words)
+
     def test_python_raw(self):
-        """Test Python."""
+        """Test Python raw strings."""
 
         bad_words = ['helo', 'begn']
         good_words = ['yes', 'word']
@@ -94,7 +112,7 @@ class TestPythonStrings(util.PluginTestCase):
         self.assert_spellcheck('.pystrings.yml', bad_words)
 
     def test_python_unicode(self):
-        """Test Python."""
+        """Test Python Unicode strings."""
 
         bad_words = ['helo', 'begn']
         good_words = ['yes', 'word']
@@ -111,7 +129,7 @@ class TestPythonStrings(util.PluginTestCase):
         self.assert_spellcheck('.pystrings.yml', bad_words)
 
     def test_python_bytes(self):
-        """Test Python."""
+        """Test Python byte strings."""
 
         bad_words = ['helo', 'begn']
         good_words = ['yes', 'word']
@@ -128,7 +146,7 @@ class TestPythonStrings(util.PluginTestCase):
         self.assert_spellcheck('.pystrings.yml', bad_words)
 
     def test_python_raw_bytes(self):
-        """Test Python."""
+        """Test Python raw byte strings."""
 
         bad_words = ['helo', 'begn']
         good_words = ['yes', 'word']
@@ -145,7 +163,7 @@ class TestPythonStrings(util.PluginTestCase):
         self.assert_spellcheck('.pystrings.yml', bad_words)
 
     def test_python_format(self):
-        """Test Python."""
+        """Test Python format strings."""
 
         bad_words = ['helo', 'begn']
         good_words = ['yes', 'word']
@@ -162,8 +180,8 @@ class TestPythonStrings(util.PluginTestCase):
         self.mktemp('test.txt', template, 'utf-8')
         self.assert_spellcheck('.pystrings.yml', bad_words)
 
-    def test_python_raw_sformat(self):
-        """Test Python."""
+    def test_python_raw_format(self):
+        """Test Python raw format strings."""
 
         bad_words = ['helo', 'begn']
         good_words = ['yes', 'word']

--- a/tests/filters/test_python.py
+++ b/tests/filters/test_python.py
@@ -141,6 +141,7 @@ class TestPythonStrings(util.PluginTestCase):
         ).format(
             '\\x03'.join(bad_words + good_words)
         )
+        bad_words.append('aaaa')
         self.mktemp('test.txt', template, 'utf-8')
         self.assert_spellcheck('.pystrings.yml', bad_words)
 

--- a/tests/filters/test_python.py
+++ b/tests/filters/test_python.py
@@ -141,7 +141,6 @@ class TestPythonStrings(util.PluginTestCase):
         ).format(
             '\\x03'.join(bad_words + good_words)
         )
-        bad_words.append('aaaa')
         self.mktemp('test.txt', template, 'utf-8')
         self.assert_spellcheck('.pystrings.yml', bad_words)
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -134,7 +134,7 @@ class PluginTestCase(unittest.TestCase):
                 "'{}', is not compatible with '{}'".format(running, required)
             )
 
-    def assert_spellcheck(self, config_file, expected, names=None, groups=None, sources=None, verbose=0):
+    def assert_spellcheck(self, config_file, expected, names=None, groups=None, sources=None, verbose=4):
         """Spell check."""
 
         hunspell_location = which(HUNSPELL)
@@ -158,7 +158,8 @@ class PluginTestCase(unittest.TestCase):
                 sources=sources,
                 checker='hunspell',
                 binary=hunspell_location,
-                debug=True
+                debug=True,
+                verbose=verbose
             ):
                 if results.error:
                     print(results.error)
@@ -173,7 +174,8 @@ class PluginTestCase(unittest.TestCase):
                 sources=sources,
                 checker='aspell',
                 binary=aspell_location,
-                debug=True
+                debug=True,
+                verbose=verbose
             ):
                 if results.error:
                     print(results.error)


### PR DESCRIPTION
Working to add string support to various existing plugins. String processing would of course be optional.

- [x] Properly handle and extract text from strings: byte, Unicode, and format. We want to handle string escapes appropriate to the string type.  In format, we want to just strip out format stuff `{key}` etc. Maybe allow filtering out certain string types if desired: raw, bytes, format, etc.?

- [x] Properly handle and extract text from JavaScript string escapes.

- [x] Probably doesn't make sense to extract string content from stylesheets. I feel like you'd get very little actual content. Mainly font names, urls, b64 data, and the occasional `content`.  I'll think about it.

- [x] One notable thing is I've found `\r` is very annoying. I've at least added a common `norm_nl` function to the base plugin to normalize string line endings. In general, I will ensure that all builtin plugins normalize line endings in chunks they return. Context plugin by default will normailze line endings of any incoming text to make creating patterns easier as I always forget to think about `\r` in my patterns.  I will allow it to be turned off if someone has a reason to, but by default, we are just going to always filter it.

Closes #34.