### PR TITLE
Rework allow handling and detection of types of strings

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -89,6 +89,7 @@ subclassed
 subclassing
 sublicense
 substring
+subtypes
 syntaxes
 trigraphs
 tuple

--- a/docs/src/markdown/filters/cpp.md
+++ b/docs/src/markdown/filters/cpp.md
@@ -32,6 +32,14 @@ matrix:
   - js_files/**/*.{cpp,hpp,c,h}
 ```
 
+## Filtering String types
+
+When `strings` is enabled, you can specify which strings you want to allow via the `string_types` option. Valid string types are `S` for standard, `L` for long/wide, `U` for Unicode (all variants), and `R` for raw.  Case is not important, and the default value is `sul`.  
+
+If you do not explicitly specify `U` or `L`, `S` is assumed. For instance, if only `R` was specified, there is actually multiple types of `R`: standard, Unicode, and wide. Since Unicode or wide were not explicitly specified, `S` is assumed to be enabled and both `S` and `S` variants of `R` will be searched. If you were to specify only `UR` you would be searching `U` strings and `U` variants of `R` strings and not `S` strings. To search both `U` and `S` variants you would need to explicitly specify them via `SUR`.
+
+In short, if you only enable `R`, you will be searching the normal string of that type as well as `R` as the `R` is a subtypes of of `U`, `S` and `L`. If greater resolution is needed, this approach may be reconsidered in the future.
+
 ## Generic Mode
 
 C/C++ style comments are not exclusive to C/C++. Many different file types have adopted similar style comments. The CPP filter has a generic mode which allows for a C/C++ style comment extraction without all the C/C++ specific considerations. Simply enable `generic_mode` via the [options](#options).

--- a/docs/src/markdown/filters/cpp.md
+++ b/docs/src/markdown/filters/cpp.md
@@ -36,9 +36,7 @@ matrix:
 
 When `strings` is enabled, you can specify which strings you want to allow via the `string_types` option. Valid string types are `S` for standard, `L` for long/wide, `U` for Unicode (all variants), and `R` for raw.  Case is not important, and the default value is `sul`.  
 
-If you do not explicitly specify `U` or `L`, `S` is assumed. For instance, if only `R` was specified, there is actually multiple types of `R`: standard, Unicode, and wide. Since Unicode or wide were not explicitly specified, `S` is assumed to be enabled and both `S` and `S` variants of `R` will be searched. If you were to specify only `UR` you would be searching `U` strings and `U` variants of `R` strings and not `S` strings. To search both `U` and `S` variants you would need to explicitly specify them via `SUR`.
-
-In short, if you only enable `R`, you will be searching the normal string of that type as well as `R` as the `R` is a subtypes of of `U`, `S` and `L`. If greater resolution is needed, this approach may be reconsidered in the future.
+If specifying `R`, you must also specify either `U`, `L`, or `S` as raw strings are also either `S`, `L`, or `S` strings. Selecting `UR` will select both Unicode strings and Unicode raw strings. If you need to target just raw strings, you can use `R*` which will target all raw string types: raw Unicode, raw wide, and raw standard. You can use `*` for other types as well. You can also just specify `*` by itself to target all string types.
 
 ## Generic Mode
 
@@ -72,7 +70,7 @@ Options            | Type     | Default         | Description
 `exec_charset`     | string   | `#!py3 'utf-8`  | Set normal string encoding.
 `wide_charset_size`| int      | `#!py3 4`       | Set wide string character byte width.
 `wide_exec_charset`| string   | `#!py3 'utf-32` | Set wide string encoding.
-`allowed`          | string   | `#!py3 "sul"`   | Set the allowed string types to capture: standard strings (`s`),  wide (`l`), Unicode (`u`), and raw (`r`).
+`string_types`     | string   | `#!py3 "sul"`   | Set the allowed string types to capture: standard strings (`s`),  wide (`l`), Unicode (`u`), and raw (`r`). `*` captures all strings, or when used with a type, captures all variants of that type `r*`.
 `prefix`           | string   | `#!py3 'cpp'`   | Change the category prefix.
 
 ## Categories

--- a/docs/src/markdown/filters/cpp.md
+++ b/docs/src/markdown/filters/cpp.md
@@ -64,7 +64,7 @@ Options            | Type     | Default         | Description
 `exec_charset`     | string   | `#!py3 'utf-8`  | Set normal string encoding.
 `wide_charset_size`| int      | `#!py3 4`       | Set wide string character byte width.
 `wide_exec_charset`| string   | `#!py3 'utf-32` | Set wide string encoding.
-`allowed`          | string   | `#!py3 "suw"`   | Set the allowed string types to capture: standard strings (`s`),  wide (`wide`), Unicode (`u`), and raw (`r`).
+`allowed`          | string   | `#!py3 "sul"`   | Set the allowed string types to capture: standard strings (`s`),  wide (`l`), Unicode (`u`), and raw (`r`).
 `prefix`           | string   | `#!py3 'cpp'`   | Change the category prefix.
 
 ## Categories

--- a/docs/src/markdown/filters/python.md
+++ b/docs/src/markdown/filters/python.md
@@ -4,7 +4,7 @@
 
 When first in the chain, the Python filter will look for the encoding of the file in the header, and convert to Unicode accordingly. It will assume `utf-8` if no encoding header is found, and the user has not overridden the fallback encoding.
 
-Text is returned in chunks based on the context of the captured text. Each docstrings, inline comment, or non-docstring is returned as their own chunk.
+Text is returned in chunks based on the context of the captured text. Each docstring, inline comment, or normal string is returned as their own chunk.
 
 In general, regardless of Python version, strings *should* be parsed *almost* identically. PySpelling, unless configured otherwise, will decode string escapes and strip out format variables from f-strings. Decoding of escapes and stripping format variables is not dependent on what version of Python PySpelling is run on, but is based on the string prefixes that PySpelling encounters. There are two cases that may cause quirks related to Python version:
 
@@ -25,11 +25,9 @@ matrix:
 
 ## Filtering String types
 
-When `strings` is enabled, you can specify which strings you want to allow via the `string_types` option. Valid string types are `b` for bytes, `f` for format, `u` for Unicode (all variants), and `R` for raw.  `f` refers to f-strings, not strings in the form `#!py3 "my string {}".format(value)"`. Case is not important, and the default value is `fu`.
+When `strings` is enabled, you can specify which strings you want to allow via the `string_types` option. Valid string types are `b` for bytes, `f` for format, `u` for Unicode, and `r` for raw.  `f` refers to f-strings, not strings in the form `#!py3 "my string {}".format(value)"`, and though f-strings are Unicode, they are treated as a separate string type from Unicode. Case is not important, and the default value is `fu`.
 
-If you do not explicitly specify `b`, `u` is assumed. For instance, if only `r` was specified, there is actually multiple types of `r`: bytes and Unicode. Since bytes was not explicitly specified, `u` is assumed to be enabled and both `u` and `u` variants of `r` will be searched. If you specified `br`, you would be searching `b` strings and `b` variants of `r` and not `u` strings. To search both `u` and `b` strings you would need to specify `ubr`.
-
-In short, if you enable `f` or `r`, you will be searching the normal string of that type as well as `f` and `r` types are subtypes of of `u` and `b` (`f` does not have `b` variants). If greater resolution is needed, this approach may be reconsidered in the future.
+If specifying `r`, you must also specify either `u`, `b`, or `f` as raw strings are also either `u`, `b`, or `f` strings. Selecting `ur` will select both Unicode strings and Unicode raw strings. If you need to target just raw strings, you can use `r*` which will target all raw strings types: raw Unicode, raw format, and raw bytes. You can use `*` for other types as well. You can also just specify `*` by itself to target all string types.
 
 ## Options
 
@@ -40,7 +38,7 @@ Options          | Type     | Default       | Description
 `group_comments` | bool     | `#!py3 False` | Group consecutive Python comments as one `SourceText` entry.
 `decode_escapes` | bool     | `#!py3 True`  | Decode escapes and strip out format variables. Behavior is based on the string type that is encountered. This affects both docstrings and non-docstrings.
 `strings`        | string   | `#!py3 False` | Return `SourceText` entries for each string (non-docstring).
-`strint_types`   | string   | `#!py3 fu`    | Specifies which string types `strings` searches: bytes (`b`), format (`f`), raw (`r`), and Unicode (`u`). This does not affect docstrings. When `docstrings` is enabled, all docstrings are parsed.
+`string_types`   | string   | `#!py3 fu`    | Specifies which string types `strings` searches: bytes (`b`), format (`f`), raw (`r`), and Unicode (`u`).  `*` captures all strings, or when used with a type, captures all variants of that type `r*`. This does not affect docstrings. When `docstrings` is enabled, all docstrings are parsed.
 
 ## Categories
 

--- a/docs/src/markdown/filters/python.md
+++ b/docs/src/markdown/filters/python.md
@@ -23,6 +23,14 @@ matrix:
   - pyspelling/**/*.py
 ```
 
+## Filtering String types
+
+When `strings` is enabled, you can specify which strings you want to allow via the `string_types` option. Valid string types are `b` for bytes, `f` for format, `u` for Unicode (all variants), and `R` for raw.  `f` refers to f-strings, not strings in the form `#!py3 "my string {}".format(value)"`. Case is not important, and the default value is `fu`.
+
+If you do not explicitly specify `b`, `u` is assumed. For instance, if only `r` was specified, there is actually multiple types of `r`: bytes and Unicode. Since bytes was not explicitly specified, `u` is assumed to be enabled and both `u` and `u` variants of `r` will be searched. If you specified `br`, you would be searching `b` strings and `b` variants of `r` and not `u` strings. To search both `u` and `b` strings you would need to specify `ubr`.
+
+In short, if you enable `f` or `r`, you will be searching the normal string of that type as well as `f` and `r` types are subtypes of of `u` and `b` (`f` does not have `b` variants). If greater resolution is needed, this approach may be reconsidered in the future.
+
 ## Options
 
 Options          | Type     | Default       | Description
@@ -32,7 +40,7 @@ Options          | Type     | Default       | Description
 `group_comments` | bool     | `#!py3 False` | Group consecutive Python comments as one `SourceText` entry.
 `decode_escapes` | bool     | `#!py3 True`  | Decode escapes and strip out format variables. Behavior is based on the string type that is encountered. This affects both docstrings and non-docstrings.
 `strings`        | string   | `#!py3 False` | Return `SourceText` entries for each string (non-docstring).
-`allowed`        | string   | `#!py3 fu`    | Specifies which string types `strings` searches: bytes (`b`), format (`f`), raw (`r`), and Unicode (`u`). This does not affect docstrings. When `docstrings` is enabled, all docstrings are parsed.
+`strint_types`   | string   | `#!py3 fu`    | Specifies which string types `strings` searches: bytes (`b`), format (`f`), raw (`r`), and Unicode (`u`). This does not affect docstrings. When `docstrings` is enabled, all docstrings are parsed.
 
 ## Categories
 

--- a/pyspelling/filters/python.py
+++ b/pyspelling/filters/python.py
@@ -145,6 +145,7 @@ class PythonFilter(filters.Filter):
     def eval_string_type(self, stype):
         """Evaluate string type."""
 
+        # If bytes is not specified, we can assume Unicode
         stype = set([c for c in stype.lower()])
         if 'b' not in stype:
             stype.add('u')

--- a/pyspelling/filters/python.py
+++ b/pyspelling/filters/python.py
@@ -104,7 +104,7 @@ class PythonFilter(filters.Filter):
             'docstrings': True,
             'strings': False,
             'group_comments': False,
-            'allowed': 'fu',
+            'string_types': 'fu',
             'decode_escapes': True
         }
 
@@ -115,14 +115,14 @@ class PythonFilter(filters.Filter):
         self.docstrings = self.config['docstrings']
         self.strings = self.config['strings']
         self.group_comments = self.config['group_comments']
-        self.allowed = self.eval_string_type(self.config['allowed'])
+        self.string_types = self.eval_string_type(self.config['string_types'])
         self.decode_escapes = self.config['decode_escapes']
 
     def validate_options(self, k, v):
         """Validate options."""
 
         super().validate_options(k, v)
-        if k == 'allowed':
+        if k == 'string_types':
             for c in v.lower():
                 if c not in 'rbuf':
                     raise ValueError("{}: '{}' is not a valid string type".format(self.__class__.__name__, c))
@@ -200,7 +200,7 @@ class PythonFilter(filters.Filter):
 
         m = RE_STRING_TYPE.match(string)
         stype = self.eval_string_type(m.group(1) if m.group(1) else '')
-        if stype - self.allowed and not docstrings:
+        if stype - self.string_types and not docstrings:
             return '', False
         is_bytes = 'b' in stype
         is_raw = 'r' in stype

--- a/pyspelling/filters/python.py
+++ b/pyspelling/filters/python.py
@@ -75,6 +75,10 @@ RE_STRING_TYPE = re.compile(r'''((?:r|u|f|b)+)?(\'''|"""|'|")(.*?)\2''', re.I | 
 
 RE_NON_PRINTABLE = re.compile(r'[\x00-\x09\x0b-\x1f\x7f-\xff]+')
 
+RE_VALID_STRING_TYPES = re.compile(r'^(?:\*|(?:[rubf]\*?)+)$', re.I)
+
+RE_ITER_STRING_TYPES = re.compile(r'(\*|[rubf]\*?)', re.I)
+
 FMT_STR = (
     'f', 'F',
     'fr', 'rf',
@@ -115,7 +119,7 @@ class PythonFilter(filters.Filter):
         self.docstrings = self.config['docstrings']
         self.strings = self.config['strings']
         self.group_comments = self.config['group_comments']
-        self.string_types = self.eval_string_type(self.config['string_types'])
+        self.string_types, self.wild_string_types = self.eval_string_type(self.config['string_types'])
         self.decode_escapes = self.config['decode_escapes']
 
     def validate_options(self, k, v):
@@ -123,9 +127,8 @@ class PythonFilter(filters.Filter):
 
         super().validate_options(k, v)
         if k == 'string_types':
-            for c in v.lower():
-                if c not in 'rbuf':
-                    raise ValueError("{}: '{}' is not a valid string type".format(self.__class__.__name__, c))
+            if RE_VALID_STRING_TYPES.match(v) is None:
+                raise ValueError("{}: '{}' does not define valid string types".format(self.__class__.__name__, v))
 
     def header_check(self, content):
         """Special Python encoding check."""
@@ -142,14 +145,38 @@ class PythonFilter(filters.Filter):
             encode = 'utf-8'
         return encode
 
-    def eval_string_type(self, stype):
+    def eval_string_type(self, text, is_string=False):
         """Evaluate string type."""
 
-        # If bytes is not specified, we can assume Unicode
-        stype = set([c for c in stype.lower()])
-        if 'b' not in stype:
+        stype = set()
+        wstype = set()
+
+        for m in RE_ITER_STRING_TYPES.finditer(text):
+            value = m.group(0)
+            if value == '*':
+                wstype.add('u')
+                wstype.add('f')
+                wstype.add('r')
+                wstype.add('b')
+            elif value.endswith('*'):
+                wstype.add(value[0].lower())
+            else:
+                stype.add(value.lower())
+
+        if is_string and 'b' not in stype and 'f' not in stype:
             stype.add('u')
-        return stype
+
+        return stype, wstype
+
+    def get_string_type(self, text):
+        """Get string type."""
+
+        return self.eval_string_type(text, True)[0]
+
+    def match_string(self, stype):
+        """Match string type."""
+
+        return not (stype - self.string_types) or bool(stype & self.wild_string_types)
 
     def replace_unicode(self, m):
         """Replace escapes."""
@@ -199,8 +226,8 @@ class PythonFilter(filters.Filter):
         """Process escapes."""
 
         m = RE_STRING_TYPE.match(string)
-        stype = self.eval_string_type(m.group(1) if m.group(1) else '')
-        if stype - self.string_types and not docstrings:
+        stype = self.get_string_type(m.group(1) if m.group(1) else '')
+        if not self.match_string(stype) and not docstrings:
             return '', False
         is_bytes = 'b' in stype
         is_raw = 'r' in stype

--- a/tests/filters/test_cpp.py
+++ b/tests/filters/test_cpp.py
@@ -169,7 +169,7 @@ class TestCPPStringAllow(util.PluginTestCase):
                   strings: true
                   line_comments: false
                   group_comments: true
-                  allowed: uws
+                  allowed: uls
             """
         ).format(self.tempdir)
         self.mktemp('.cpp.yml', config, 'utf-8')
@@ -193,7 +193,7 @@ class TestCPPStringAllow(util.PluginTestCase):
                   strings: true
                   line_comments: false
                   group_comments: true
-                  allowed: rws
+                  allowed: rls
             """
         ).format(self.tempdir)
         self.mktemp('.cpp.yml', config, 'utf-8')
@@ -241,7 +241,7 @@ class TestCPPStringAllow(util.PluginTestCase):
                   strings: true
                   line_comments: false
                   group_comments: true
-                  allowed: ruw
+                  allowed: rul
             """
         ).format(self.tempdir)
         self.mktemp('.cpp.yml', config, 'utf-8')
@@ -269,7 +269,7 @@ class TestCPPStrings(util.PluginTestCase):
                   strings: true
                   line_comments: false
                   group_comments: true
-                  allowed: ruws
+                  allowed: ruls
             """
         ).format(self.tempdir)
         self.mktemp('.cpp.yml', config, 'utf-8')

--- a/tests/filters/test_cpp.py
+++ b/tests/filters/test_cpp.py
@@ -247,6 +247,87 @@ class TestCPPStringAllow(util.PluginTestCase):
         self.mktemp('.cpp.yml', config, 'utf-8')
         self.assert_spellcheck('.cpp.yml', ["bbbb", "cccc", "dddd", "eeee", "hhhh", "iiii", "jjjj", "kkkk"])
 
+    def test_include_all(self):
+        """Test standard exclusion."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: cpp
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.cpp:
+                  strings: true
+                  line_comments: false
+                  group_comments: true
+                  string_types: '*'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.cpp.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.cpp.yml',
+            ["aaaa", "bbbb", "cccc", "dddd", "eeee", "ffff", "gggg", "hhhh", "iiii", "jjjj", "kkkk"]
+        )
+
+    def test_include_all_raw(self):
+        """Test standard exclusion."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: cpp
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.cpp:
+                  strings: true
+                  line_comments: false
+                  group_comments: true
+                  string_types: 'r*'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.cpp.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.cpp.yml',
+            ["ffff", "gggg", "hhhh", "iiii", "jjjj", "kkkk"]
+        )
+
+    def test_include_all_unicode(self):
+        """Test standard exclusion."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: cpp
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.cpp:
+                  strings: true
+                  line_comments: false
+                  group_comments: true
+                  string_types: 'u*'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.cpp.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.cpp.yml',
+            ["cccc", "dddd", "eeee", "iiii", "jjjj", "kkkk"]
+        )
+
 
 class TestCPPStrings(util.PluginTestCase):
     """Test CPP plugin."""

--- a/tests/filters/test_cpp.py
+++ b/tests/filters/test_cpp.py
@@ -169,7 +169,7 @@ class TestCPPStringAllow(util.PluginTestCase):
                   strings: true
                   line_comments: false
                   group_comments: true
-                  allowed: uls
+                  string_types: uls
             """
         ).format(self.tempdir)
         self.mktemp('.cpp.yml', config, 'utf-8')
@@ -193,7 +193,7 @@ class TestCPPStringAllow(util.PluginTestCase):
                   strings: true
                   line_comments: false
                   group_comments: true
-                  allowed: rls
+                  string_types: rls
             """
         ).format(self.tempdir)
         self.mktemp('.cpp.yml', config, 'utf-8')
@@ -217,7 +217,7 @@ class TestCPPStringAllow(util.PluginTestCase):
                   strings: true
                   line_comments: false
                   group_comments: true
-                  allowed: rus
+                  string_types: rus
             """
         ).format(self.tempdir)
         self.mktemp('.cpp.yml', config, 'utf-8')
@@ -241,7 +241,7 @@ class TestCPPStringAllow(util.PluginTestCase):
                   strings: true
                   line_comments: false
                   group_comments: true
-                  allowed: rul
+                  string_types: rul
             """
         ).format(self.tempdir)
         self.mktemp('.cpp.yml', config, 'utf-8')
@@ -269,7 +269,7 @@ class TestCPPStrings(util.PluginTestCase):
                   strings: true
                   line_comments: false
                   group_comments: true
-                  allowed: ruls
+                  string_types: ruls
             """
         ).format(self.tempdir)
         self.mktemp('.cpp.yml', config, 'utf-8')

--- a/tests/filters/test_python.py
+++ b/tests/filters/test_python.py
@@ -70,7 +70,7 @@ class TestPythonStrings(util.PluginTestCase):
               pipeline:
               - pyspelling.filters.python:
                   strings: true
-                  allowed: bfru
+                  string_types: bfru
                   group_comments: true
             """
         ).format(self.tempdir)

--- a/tests/filters/test_python.py
+++ b/tests/filters/test_python.py
@@ -201,6 +201,182 @@ class TestPythonStrings(util.PluginTestCase):
         self.assert_spellcheck('.pystrings.yml', bad_words)
 
 
+class TestPythonStringAllow(util.PluginTestCase):
+    """Test Python allow filter."""
+
+    def setup_fs(self):
+        """Setup."""
+
+        template = self.dedent(
+            r"""
+            def func():
+                s0 =   "aaaa"
+                s1 =  u"bbbb"
+                s2 =  b"cccc"
+                s3 =  f"dddd"
+                s4 =  r"eeee"
+                s5 =  br"ffff"
+                s7 =  fr"gggg"
+            """
+        )
+
+        self.mktemp('test.txt', template, 'utf-8')
+
+    def test_exclude_unicode(self):
+        """Test exclude Unicode."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: python
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.python:
+                  strings: true
+                  string_types: brf
+            """
+        ).format(self.tempdir)
+        self.mktemp('.python.yml', config, 'utf-8')
+        self.assert_spellcheck('.python.yml', ['cccc', 'dddd', 'ffff', 'gggg'])
+
+    def test_exclude_bytes(self):
+        """Test exclude bytes."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: python
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.python:
+                  strings: true
+                  string_types: urf
+            """
+        ).format(self.tempdir)
+        self.mktemp('.python.yml', config, 'utf-8')
+        self.assert_spellcheck('.python.yml', ['aaaa', 'bbbb', 'dddd', 'eeee', 'gggg'])
+
+    def test_exclude_format(self):
+        """Test exclude format."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: python
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.python:
+                  strings: true
+                  string_types: bur
+            """
+        ).format(self.tempdir)
+        self.mktemp('.python.yml', config, 'utf-8')
+        self.assert_spellcheck('.python.yml', ['aaaa', 'bbbb', 'cccc', 'eeee', 'ffff'])
+
+    def test_exclude_raw(self):
+        """Test exclude raw."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: python
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.python:
+                  strings: true
+                  string_types: buf
+            """
+        ).format(self.tempdir)
+        self.mktemp('.python.yml', config, 'utf-8')
+        self.assert_spellcheck('.python.yml', ['aaaa', 'bbbb', 'cccc', 'dddd'])
+
+    def test_include_all(self):
+        """Test include all."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: python
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.python:
+                  strings: true
+                  string_types: '*'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.python.yml', config, 'utf-8')
+        self.assert_spellcheck('.python.yml', ['aaaa', 'bbbb', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg'])
+
+    def test_include_all_raw(self):
+        """Test include all raw."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: python
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.python:
+                  strings: true
+                  string_types: 'r*'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.python.yml', config, 'utf-8')
+        self.assert_spellcheck('.python.yml', ['eeee', 'ffff', 'gggg'])
+
+    def test_include_all_unicode(self):
+        """Test include all Unicode."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: python
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.python:
+                  strings: true
+                  string_types: 'u*'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.python.yml', config, 'utf-8')
+        self.assert_spellcheck('.python.yml', ['aaaa', 'bbbb', 'eeee'])
+
+
 class TestPythonChained(util.PluginTestCase):
     """Test Python plugin."""
 


### PR DESCRIPTION
Use a similar convention as we use in Python for detecting string types in c strings and rename the `allowed` option in both CPP and Python filters.