### PR TITLE
Add support for `div p`, `div>p`, `div+p`, and `div~p`

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.0
+
+- **NEW**: Add support for `div p`, `div>p`, `div+p`, `div~p` in the HTML/XML filter's CSS selectors.
+
 ## 2.0.0
 
 - **NEW**: (Breaking change) Task names should be unique and using `--name` from the command line will only target one `name` (the last task defined with that name). If you were not using `name` to run a group of tasks, you will not notice any changes.

--- a/docs/src/markdown/filters/html.md
+++ b/docs/src/markdown/filters/html.md
@@ -34,12 +34,16 @@ The CSS selectors are based on a limited subset of CSS4 selectors.
 
 Below shows accepted selectors. When speaking about namespaces, they only apply to XHTML or when dealing with recognized foreign tags in HTML5. You must configure the CSS namespaces in the plugin options in order for them to work properly.
 
-While an effort is made to mimic CSS selector behavior, there may be some differences or quirks. We do not support all CSS selector features, but enough to make the task of ignoring tags or selectively capturing tags easy. We particularly do not support notations with ancestry such as `div > p`, `div + p`, `div p`, or `div ~ p`. The only pseudo classes that are currently supported is `:not()` and `:matches()` as they are the most helpful in the task of ignoring or capturing tags.
+While an effort is made to mimic CSS selector behavior, there may be some differences or quirks. We do not support all CSS selector features, but enough to make the task of ignoring tags or selectively capturing tags easy. The only pseudo classes that are currently supported is `:not()` and `:matches()` as they are the most helpful in the task of ignoring or capturing tags.
 
 Selector             | Example                       | Description
 -------------------- | ----------------------------- | -----------
 `Element`            | `div`                         | Select the `<div>` element (will be under the default namespace if defined for XHTML).
 `Element, Element`   | `div, h1`                     | Select the `<div>` element and the `<h1>` element.
+`Element Element`    | `div p`                       | Select all `<p>` elements inside `<div>` elements.
+`Element>Element`    | `div > p`                     | Select all `<p>` elements where the parent is a `<div>` element.
+`Element+Element`    | `div + p`                     | Select all `<p>` elements that are placed immediately after `<div>` elements.
+`Element~Element`    | `p ~ ul`                      | Select every `<ul>` element that is preceded by a `<p>` element.
 `namespace|Element`  | `svg|circle`                  | Select the `<circle>` element which also has the namespace `svg`.
 `*|Element`          | `*|div`                       | Select the `<div>` element with or without a namespace.
 `namespace|*`        | `svg|*`                       | Select any element with the namespace `svg`.

--- a/docs/src/markdown/filters/xml.md
+++ b/docs/src/markdown/filters/xml.md
@@ -30,7 +30,7 @@ The CSS selectors are based on a limited subset of CSS4 selectors. The same sele
 
 Below shows accepted selectors. You must configure the CSS namespaces in the plugin options in order for them to work properly.
 
-While an effort is made to mimic CSS selector behavior, there may be some differences or quirks. We do not support all CSS selector features, but enough to make the task of ignoring tags or selectively capturing tags easy. We particularly do not support notations with ancestry such as `div > p`, `div + p`, `div p`, or `div ~ p`. The only pseudo classes that are currently supported is `:not()` and `:matches()` as they are the most helpful in the task of ignoring or capturing tags.
+While an effort is made to mimic CSS selector behavior, there may be some differences or quirks. We do not support all CSS selector features, but enough to make the task of ignoring tags or selectively capturing tags easy. The only pseudo classes that are currently supported is `:not()` and `:matches()` as they are the most helpful in the task of ignoring or capturing tags.
 
 Examples below are using HTML, but can be adapted for XML.
 
@@ -38,6 +38,10 @@ Selector             | Example                       | Description
 -------------------- | ----------------------------- | -----------
 `Element`            | `div`                         | Select the `<div>` element (will be under the default namespace if defined for XHTML).
 `Element, Element`   | `div, h1`                     | Select the `<div>` element and the `<h1>` element.
+`Element Element`    | `div p`                       | Select all `<p>` elements inside `<div>` elements.
+`Element>Element`    | `div > p`                     | Select all `<p>` elements where the parent is a `<div>` element.
+`Element+Element`    | `div + p`                     | Select all `<p>` elements that are placed immediately after `<div>` elements.
+`Element~Element`    | `p ~ ul`                      | Select every `<ul>` element that is preceded by a `<p>` element.
 `namespace|Element`  | `svg|circle`                  | Select the `<circle>` element which also has the namespace `svg`.
 `*|Element`          | `*|div`                       | Select the `<div>` element with or without a namespace.
 `namespace|*`        | `svg|*`                       | Select any element with the namespace `svg`.

--- a/pyspelling/__meta__.py
+++ b/pyspelling/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(2, 0, 0, "final")
+__version_info__ = Version(2, 1, 0, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/tests/filters/test_html.py
+++ b/tests/filters/test_html.py
@@ -237,6 +237,128 @@ class TestHtml5AttrNamespace(util.PluginTestCase):
         self.assert_spellcheck('.html5.yml', ['cccc'])
 
 
+class TestHtml5AdvancedSelectors(util.PluginTestCase):
+    """Test advanced CSS selectors."""
+
+    def setup_fs(self):
+        """Setup file system."""
+
+        template = self.dedent(
+            """
+            <!DOCTYPE html>
+            <html>
+            <head>
+              <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+            </head>
+            <body>
+              <div class="aaaa">aaaa
+                  <p class="bbbb">bbbb</p>
+                  <p class="cccc">cccc</p>
+                  <p class="dddd">dddd</p>
+                  <div class="eeee">eeee
+                  <div class="ffff">ffff
+                  <div class="gggg">gggg
+                      <p class="hhhh">hhhh</p>
+                      <p class="iiii zzzz">iiii</p>
+                      <p class="jjjj">jjjj</p>
+                      <div class="kkkk">kkkk
+                          <p class="llll zzzz">llll</p>
+                      </div>
+                  </div>
+                  </div>
+                  </div>
+              </div>
+            </body>
+            </body>
+            </html>
+            """
+        )
+
+        self.mktemp('test.txt', template, 'utf-8')
+
+    def test_css_parents(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'body div.gggg > p.zzzz'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'aaaa', 'bbbb', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'hhhh', 'jjjj', 'kkkk', 'llll'
+            ]
+        )
+
+    def test_css_siblings(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'p.bbbb ~ div.gggg > p.hhhh + p'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'aaaa', 'bbbb', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'hhhh', 'jjjj', 'kkkk', 'llll'
+            ]
+        )
+
+    def test_css_pseudo(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'p.bbbb ~ div > div > div :not(p.hhhh + .zzzz)'
+                  - 'p:matches(.aaaa + .bbbb)'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'aaaa', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'iiii'
+            ]
+        )
+
+
 class TestHTML5LIB(util.PluginTestCase):
     """Test HTML plugin with `html5lib`."""
 


### PR DESCRIPTION
Add support for CSS selectors with ancestry related references.  Ensure works inside pseudo selectors as well. Closes #51.