### PR TITLE
:has() support

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -4,6 +4,7 @@
 
 - **NEW**: Add support for `div p`, `div>p`, `div+p`, `div~p` in the HTML/XML filter's CSS selectors. (#51)
 - **NEW**: Add support for the `:root` CSS selector. (#57)
+- **NEW**: Add support for experimental `:has()` selector. (#54)
 - **FIX**: According to CSS4 specification, `:is()` is the final name for `:matches()` but the `:matches()` is an allowed alias. (#53)
 - **FIX**: Allow `:not()` to be nested in `:is()`/`:matches()`. (#56)
 

--- a/docs/src/markdown/filters/html.md
+++ b/docs/src/markdown/filters/html.md
@@ -65,10 +65,17 @@ Selector             | Example                       | Description
 `[attribute*=value]` | `a[href*="sometext"]`         | Selects every `<a>` element whose `href` attribute value contains the substring `sometext`.
 `:not(sel, sel)`     | `:not(.some-class, #some-id)` | Selects elements that do not have class `some-class` and ID `some-id`.
 `:is(sel, sel)`      | `:is(div, .some-class)`       | Selects elements that are not `<div>` and do not have class `some-class`. The alias `:matches` is allowed as well.
+`:has(> sel, + sel)` | `:has(> div, + p)`            | Selects elements that have a direct child that is a `<div>` or that have sibling of `<p>` immediately following.
 `:root`              | `:root`                       | Selects the root element. In HTML, this is usually the `<html>` element.
 
+!!! new "New 2.1.0"
+    Support for `div p`, `div>p`, `div+p`, `div~p`, `:is()`, `:has()` and `:root`.
+
+!!! warning ":has()"
+    `:has()` implementation is experimental and may change. There are currently no reference implementation available in any browsers, not to mention the CSS4 specifications have not been finalized, so current implementation is based on our best interpretation.
+
 !!! note ":not()"
-    While you can nest `:not()` inside of `:is()`, you cannot match `:is()` or `:not()` inside of `:not()`. This is due to a limitation imposed by the CSS4 specification, not a limitation in our implementation.
+    While you can nest `:not()` inside of `:is()` or `:has()`, you cannot match `:is()`, `:has()` or `:not()` inside of `:not()`. This is due to a limitation imposed by the CSS4 specification, not a limitation in our implementation.
 
 ## Options
 

--- a/docs/src/markdown/filters/xml.md
+++ b/docs/src/markdown/filters/xml.md
@@ -61,7 +61,14 @@ Selector             | Example                       | Description
 `[attribute*=value]` | `a[href*="sometext"]`         | Selects every `<a>` element whose `href` attribute value contains the substring `sometext`.
 `:not(sel, sel)`     | `:not(.some-class, #some-id)` | Selects elements that do not have class `some-class` and ID `some-id`.
 `:is(sel, sel)`      | `:is(div, .some-class)`       | Selects elements that are not `<div>` and do not have class `some-class`. The alias `:matches` is allowed as well.
+`:has(> sel, + sel)` | `:has(> div, + p)`            | Selects elements that have a direct child that is a `<div>` or that have sibling of `<p>` immediately following.
 `:root`              | `:root`                       | Selects the root element.
+
+!!! new "New 2.1.0"
+    Support for `div p`, `div>p`, `div+p`, `div~p`, `:is()`, `:has()` and `:root`.
+
+!!! warning ":has()"
+    `:has()` implementation is experimental and may change. There are currently no reference implementation available in any browsers, so current implementation is based on our best interpretation.
 
 !!! note ":not()"
     While you can nest `:not()` inside of `:is()`, you cannot match `:is()` or `:not()` inside of `:not()`. This is due to a limitation imposed by the CSS4 specification, not a limitation in our implementation.

--- a/tests/filters/test_html.py
+++ b/tests/filters/test_html.py
@@ -320,7 +320,7 @@ class TestHtml5AdvancedSelectors(util.PluginTestCase):
               - pyspelling.filters.html:
                   mode: html5
                   ignores:
-                  - 'p.bbbb ~ div.gggg > p.hhhh + p'
+                  - 'p.bbbb ~ div div.gggg > p.hhhh + p'
             """
         ).format(self.tempdir)
         self.mktemp('.html5.yml', config, 'utf-8')
@@ -348,13 +348,13 @@ class TestHtml5AdvancedSelectors(util.PluginTestCase):
                   mode: html5
                   ignores:
                   - 'p.bbbb ~ div > div > div :not(p.hhhh + .zzzz)'
-                  - 'p:is(.aaaa + .bbbb)'
+                  - 'p:is(.bbbb + .cccc)'
             """
         ).format(self.tempdir)
         self.mktemp('.html5.yml', config, 'utf-8')
         self.assert_spellcheck(
             '.html5.yml', [
-                'aaaa', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'iiii'
+                'aaaa', 'bbbb', 'dddd', 'eeee', 'ffff', 'gggg', 'iiii'
             ]
         )
 
@@ -382,6 +382,153 @@ class TestHtml5AdvancedSelectors(util.PluginTestCase):
         self.assert_spellcheck(
             '.html5.yml', [
                 'aaaa', 'eeee', 'ffff', 'gggg', 'kkkk', 'llll'
+            ]
+        )
+
+    def test_has_pseudo(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'div:not(.aaaa):has(.kkkk > p.llll)'
+                  - 'p:has(+ .dddd:has(+ div .jjjj))'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'aaaa', 'bbbb', 'dddd'
+            ]
+        )
+
+    def test_has_pseudo2(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'p:has(~ .jjjj)'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'aaaa', 'bbbb', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'jjjj', 'kkkk', 'llll'
+            ]
+        )
+
+
+class TestHtml5AdvancedSelectors2(util.PluginTestCase):
+    """Test advanced CSS selectors."""
+
+    def setup_fs(self):
+        """Setup file system."""
+
+        template = self.dedent(
+            """
+            <!DOCTYPE html>
+            <html>
+            <head>
+              <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+            </head>
+            <body>
+              <div class="aaaa">aaaa
+                  <p class="bbbb">bbbb</p>
+              </div>
+              <div class="cccc">cccc
+                  <p class="dddd">dddd</p>
+              </div>
+              <div class="eeee">eeee
+                  <p class="ffff">ffff</p>
+              </div>
+              <div class="gggg">gggg
+                  <p class="hhhh">hhhh</p>
+              </div>
+              <div class="iiii">iiii
+                  <p class="jjjj">jjjj</p>
+              </div>
+            </body>
+            </body>
+            </html>
+            """
+        )
+
+        self.mktemp('test.txt', template, 'utf-8')
+
+    def test_has_list(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'div:has(> .bbbb, .ffff, .jjjj)'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'cccc', 'dddd', 'gggg', 'hhhh'
+            ]
+        )
+
+    def test_not_has_list(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'div:has(> :not(.bbbb, .ffff, .jjjj))'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'aaaa', 'bbbb', 'eeee', 'ffff', 'iiii', 'jjjj'
             ]
         )
 


### PR DESCRIPTION
Closes #54.

This is our best interpretation of the specifications.  Hopefully it is spot on, and if not, I guess we'll fix it when we discover it 😄 .  The CSS4 spec has not been finalized and this feature has not been implemented by any browser, so we have no reference implementation to base this off of. But it works well enough for what PySpelling would need.