### PR TITLE
Add support for :first-*, :last-*, :only-*, :nth-*, and :empty selectors.

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -8,7 +8,6 @@ CPP
 CSS
 Changelog
 Cygwin
-EmojiOne
 GitHub
 GitLab
 Homebrew
@@ -94,6 +93,7 @@ subtypes
 syntaxes
 trigraphs
 tuple
+un
 validator
 whitespace
 wildcard

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 2.2.0
+
+- **NEW**: Add support for CSS4 selectors: `:empty`, `:first-child`, `:last-child`, `:only-child`, `:first-of-type`, `:last-of-type`, `:only-of-type`, `:nth-child(an+b [of S]?)`, `:nth-last-child(an+b [of S]?)`, `:nth-of-type(an+b)`, and `:nth-last-of-type(an+b)`. (#58)
+
 ## 2.1.1
 
-- **FIX**: CSS4 allows `:not()`, `:has()`, and `:is()` to be nested in `:not()`.
+- **FIX**: CSS4 allows `:not()`, `:has()`, and `:is()` to be nested in `:not()`. (#62)
 
 ## 2.1.0
 

--- a/docs/src/markdown/filters/html.md
+++ b/docs/src/markdown/filters/html.md
@@ -30,49 +30,64 @@ matrix:
 
 ## Supported CSS Selectors
 
-The CSS selectors are based on a limited subset of CSS4 selectors.
+The CSS selectors are based on a limited subset of CSS4 selectors. Primarily support has been added for selectors that were feasible to implement and most likely to get practical use in context of how PySpelling uses them.
 
 Below shows accepted selectors. When speaking about namespaces, they only apply to XHTML or when dealing with recognized foreign tags in HTML5. You must configure the CSS namespaces in the plugin options in order for them to work properly.
 
-While an effort is made to mimic CSS selector behavior, there may be some differences or quirks. We do not support all CSS selector features, but enough to make the task of ignoring tags or selectively capturing tags easy. The only pseudo classes that are currently supported is `:not()` and `:matches()` as they are the most helpful in the task of ignoring or capturing tags.
+While an effort is made to mimic CSS selector behavior, there may be some differences or quirks, please report issues if any are found. We do not support all CSS selector features, but enough to make the task of ignoring tags or selectively capturing tags easy.
 
-Selector             | Example                       | Description
--------------------- | ----------------------------- | -----------
-`Element`            | `div`                         | Select the `<div>` element (will be under the default namespace if defined for XHTML).
-`Element, Element`   | `div, h1`                     | Select the `<div>` element and the `<h1>` element.
-`Element Element`    | `div p`                       | Select all `<p>` elements inside `<div>` elements.
-`Element>Element`    | `div > p`                     | Select all `<p>` elements where the parent is a `<div>` element.
-`Element+Element`    | `div + p`                     | Select all `<p>` elements that are placed immediately after `<div>` elements.
-`Element~Element`    | `p ~ ul`                      | Select every `<ul>` element that is preceded by a `<p>` element.
-`namespace|Element`  | `svg|circle`                  | Select the `<circle>` element which also has the namespace `svg`.
-`*|Element`          | `*|div`                       | Select the `<div>` element with or without a namespace.
-`namespace|*`        | `svg|*`                       | Select any element with the namespace `svg`.
-`|Element`           | `|div`                        | Select `<div>` elements without a namespace.
-`|*`                 | `|*`                          | Select any element without a namespace.
-`*|*`                | `*|*`                         | Select all elements with any or no namespace.
-`*`                  | `*`                           | Select all elements. If a default namespace is defined, it will be any element under the default namespace.
-`.class`             | `.some-class`                 | Select all elements with the class `some-class`.
-`#id`                | `#some-id`                    | Select the element with the ID `some-id`.
-`[attribute]`        | `[target]`                    | Selects all elements with a `target` attribute.
-`[ns|attribute]`     | `[xlink|href]`                | Selects elements with the attribute `href` and the namespace `xlink` (assuming it has been configured in the `namespaces` option).
-`[*|attribute]`      | `[*|name]`                    | Selects any element with a `name` attribute that has a namespace or not.
-`[|attribute]`       | `[|name]`                     | Selects any element with a `name` attribute. `[|name]` is equivalent to `[name]`.
-`[attribute=value]`  | `[target=_blank]`             | Selects all attributes with `target="_blank"`.
-`[attribute~=value]` | `[title~=flower]`             | Selects all elements with a `title` attribute containing the word `flower`.
-`[attribute|=value]` | `[lang|=en]`                  | Selects all elements with a `lang` attribute value starting with `en`.
-`[attribute^=value]` | `a[href^="https"]`            | Selects every `<a>` element whose `href` attribute value begins with `https`.
-`[attribute$=value]` | `a[href$=".pdf"]`             | Selects every `<a>` element whose `href` attribute value ends with `.pdf`.
-`[attribute*=value]` | `a[href*="sometext"]`         | Selects every `<a>` element whose `href` attribute value contains the substring `sometext`.
-`:not(sel, sel)`     | `:not(.some-class, #some-id)` | Selects elements that do not have class `some-class` and ID `some-id`.
-`:is(sel, sel)`      | `:is(div, .some-class)`       | Selects elements that are not `<div>` and do not have class `some-class`. The alias `:matches` is allowed as well.
-`:has(> sel, + sel)` | `:has(> div, + p)`            | Selects elements that have a direct child that is a `<div>` or that have sibling of `<p>` immediately following.
-`:root`              | `:root`                       | Selects the root element. In HTML, this is usually the `<html>` element.
+Selector                        | Example                       | Description
+------------------------------- | ----------------------------- | -----------
+`Element`                       | `div`                         | Select the `<div>` element (will be under the default namespace if defined for XHTML).
+`Element, Element`              | `div, h1`                     | Select the `<div>` element and the `<h1>` element.
+`Element Element`               | `div p`                       | Select all `<p>` elements inside `<div>` elements.
+`Element>Element`               | `div > p`                     | Select all `<p>` elements where the parent is a `<div>` element.
+`Element+Element`               | `div + p`                     | Select all `<p>` elements that are placed immediately after `<div>` elements.
+`Element~Element`               | `p ~ ul`                      | Select every `<ul>` element that is preceded by a `<p>` element.
+`namespace|Element`             | `svg|circle`                  | Select the `<circle>` element which also has the namespace `svg`.
+`*|Element`                     | `*|div`                       | Select the `<div>` element with or without a namespace.
+`namespace|*`                   | `svg|*`                       | Select any element with the namespace `svg`.
+`|Element`                      | `|div`                        | Select `<div>` elements without a namespace.
+`|*`                            | `|*`                          | Select any element without a namespace.
+`*|*`                           | `*|*`                         | Select all elements with any or no namespace.
+`*`                             | `*`                           | Select all elements. If a default namespace is defined, it will be any element under the default namespace.
+`.class`                        | `.some-class`                 | Select all elements with the class `some-class`.
+`#id`                           | `#some-id`                    | Select the element with the ID `some-id`.
+`[attribute]`                   | `[target]`                    | Selects all elements with a `target` attribute.
+`[ns|attribute]`                | `[xlink|href]`                | Selects elements with the attribute `href` and the namespace `xlink` (assuming it has been configured in the `namespaces` option).
+`[*|attribute]`                 | `[*|name]`                    | Selects any element with a `name` attribute that has a namespace or not.
+`[|attribute]`                  | `[|name]`                     | Selects any element with a `name` attribute. `[|name]` is equivalent to `[name]`.
+`[attribute=value]`             | `[target=_blank]`             | Selects all attributes with `target="_blank"`.
+`[attribute~=value]`            | `[title~=flower]`             | Selects all elements with a `title` attribute containing the word `flower`.
+`[attribute|=value]`            | `[lang|=en]`                  | Selects all elements with a `lang` attribute value starting with `en`.
+`[attribute^=value]`            | `a[href^="https"]`            | Selects every `<a>` element whose `href` attribute value begins with `https`.
+`[attribute$=value]`            | `a[href$=".pdf"]`             | Selects every `<a>` element whose `href` attribute value ends with `.pdf`.
+`[attribute*=value]`            | `a[href*="sometext"]`         | Selects every `<a>` element whose `href` attribute value contains the substring `sometext`.
+`:not(sel, sel)`                | `:not(.some-class, #some-id)` | Selects elements that do not have class `some-class` and ID `some-id`.
+`:is(sel, sel)`                 | `:is(div, .some-class)`       | Selects elements that are not `<div>` and do not have class `some-class`. The alias `:matches` is allowed as well. In CSS4 `:where` is like `:is` except specificity is always zero. PySpelling doesn't care about specificity, so `:where` is exactly like `:is`.
+`:has(> sel, + sel)`            | `:has(> div, + p)`            | Selects elements that have a direct child that is a `<div>` or that have sibling of `<p>` immediately following.
+`:first-child`                  | `p:first-child`               | Selects every `<p>` element that is the first child of its parent.
+`:last-child`                   | `p:last-child`                | Selects every `<p>` element that is the last child of its parent.
+`:first-of-type`                | `p:first-of-type`             | Selects every `<p>` element that is the first `<p>` element of its parent.
+`:last-of-type`                 | `p:last-of-type`              | Selects every `<p>` element that is the last `<p>` element of its parent.
+`:only-child`                   | `p:only-child`                | Selects every `<p>` element that is the only child of its parent.
+`:only-of-type`                 | `p:only-of-type`              | Selects every `<p>` element that is the only `<p>` element of its parent.
+`:nth-child(an+b [of S]?)`      | `p:nth-child(2)`              | Selects every `<p>` element that is the second child of its parent. Please see CSS specification for more info on format.
+`:nth-last-child(an+b [of S]?)` | `p:nth-last-child(2)`         | Selects every `<p>` element that is the second child of its parent, counting from the last child. Please see CSS specification for more info on format.
+`:nth-of-type(an+b)`            | `p:nth-of-type(2)`            | Selects every `<p>` element that is the second `<p>` element of its parent. Please see CSS specification for more info on format.
+`:nth-last-of-type(an+b)`       | `p:nth-last-of-type(2)`       | Selects every `<p>` element that is the second `<p>` element of its parent, counting from the last child. Please see CSS specification for more info on format.
+`:root`                         | `:root`                       | Selects the root element. In HTML, this is usually the `<html>` element.
+`:empty`                        | `p:empty`                     | Selects every `<p>` element that has no children and either no text. Whitespace and comments are ignored.
 
-!!! new "New 2.1.0"
-    Support for `div p`, `div>p`, `div+p`, `div~p`, `:is()`, `:has()` and `:root`.
+!!! new "New"
+    Support for `div p`, `div>p`, `div+p`, `div~p`, `:is()`, `:has()` and `:root` was added in 2.1.0.
 
-!!! warning ":has()"
+    Support for `:nth-*`, `:first-*`, `:last-*`, `:only-*`, and `:empty` was added in 2.2.0.
+
+!!! warning "Experimental Selectors"
     `:has()` implementation is experimental and may change. There are currently no reference implementation available in any browsers, not to mention the CSS4 specifications have not been finalized, so current implementation is based on our best interpretation.
+
+    Recent addition of `:nth-*`, `:first-*`, `:last-*`, `:only-*`, is experimental. It has been implemented to the best of our understanding, especially `of S` support. Any issues with the should be reported.
 
 ## Options
 

--- a/docs/src/markdown/filters/html.md
+++ b/docs/src/markdown/filters/html.md
@@ -87,7 +87,7 @@ Selector                        | Example                       | Description
 !!! warning "Experimental Selectors"
     `:has()` implementation is experimental and may change. There are currently no reference implementation available in any browsers, not to mention the CSS4 specifications have not been finalized, so current implementation is based on our best interpretation.
 
-    Recent addition of `:nth-*`, `:first-*`, `:last-*`, `:only-*`, is experimental. It has been implemented to the best of our understanding, especially `of S` support. Any issues with the should be reported.
+    Recent addition of `:nth-*`, `:first-*`, `:last-*`, and `:only-*` is experimental. It has been implemented to the best of our understanding, especially `of S` support. Any issues with the should be reported.
 
 ## Options
 

--- a/docs/src/markdown/filters/xml.md
+++ b/docs/src/markdown/filters/xml.md
@@ -26,49 +26,64 @@ matrix:
 
 ## Supported CSS Selectors
 
-The CSS selectors are based on a limited subset of CSS4 selectors. The same selectors that are available for HTML are available for XML except for classes and IDs.
+The CSS selectors are based on a limited subset of CSS4 selectors. Primarily support has been added for selectors that were feasible to implement and most likely to get practical use in context of how PySpelling uses them.
 
-Below shows accepted selectors. You must configure the CSS namespaces in the plugin options in order for them to work properly.
+Below shows accepted selectors. When speaking about namespaces, they only apply to XHTML or when dealing with recognized foreign tags in HTML5. You must configure the CSS namespaces in the plugin options in order for them to work properly.
 
-While an effort is made to mimic CSS selector behavior, there may be some differences or quirks. We do not support all CSS selector features, but enough to make the task of ignoring tags or selectively capturing tags easy. The only pseudo classes that are currently supported is `:not()` and `:matches()` as they are the most helpful in the task of ignoring or capturing tags.
+While an effort is made to mimic CSS selector behavior, there may be some differences or quirks, please report issues if any are found. We do not support all CSS selector features, but enough to make the task of ignoring tags or selectively capturing tags easy.
 
 Examples below are using HTML, but can be adapted for XML.
 
-Selector             | Example                       | Description
--------------------- | ----------------------------- | -----------
-`Element`            | `div`                         | Select the `<div>` element (will be under the default namespace if defined for XHTML).
-`Element, Element`   | `div, h1`                     | Select the `<div>` element and the `<h1>` element.
-`Element Element`    | `div p`                       | Select all `<p>` elements inside `<div>` elements.
-`Element>Element`    | `div > p`                     | Select all `<p>` elements where the parent is a `<div>` element.
-`Element+Element`    | `div + p`                     | Select all `<p>` elements that are placed immediately after `<div>` elements.
-`Element~Element`    | `p ~ ul`                      | Select every `<ul>` element that is preceded by a `<p>` element.
-`namespace|Element`  | `svg|circle`                  | Select the `<circle>` element which also has the namespace `svg`.
-`*|Element`          | `*|div`                       | Select the `<div>` element with or without a namespace.
-`namespace|*`        | `svg|*`                       | Select any element with the namespace `svg`.
-`|Element`           | `|div`                        | Select `<div>` elements without a namespace.
-`|*`                 | `|*`                          | Select any element without a namespace.
-`*|*`                | `*|*`                         | Select all elements with any or no namespace.
-`*`                  | `*`                           | Select all elements. If a default namespace is defined, it will be any element under the default namespace.
-`[attribute]`        | `[target]`                    | Selects all elements with a `target` attribute.
-`[ns|attribute]`     | `[xlink|href]`                | Selects elements with the attribute `href` and the namespace `xlink` (assuming it has been configured in the `namespaces` option).
-`[*|attribute]`      | `[*|name]`                    | Selects any element with a `name` attribute that has a namespace or not.
-`[|attribute]`       | `[|name]`                     | Selects any element with a `name` attribute. `[|name]` is equivalent to `[name]`.
-`[attribute=value]`  | `[target=_blank]`             | Selects all attributes with `target="_blank"`.
-`[attribute~=value]` | `[title~=flower]`             | Selects all elements with a `title` attribute containing the word `flower`.
-`[attribute|=value]` | `[lang|=en]`                  | Selects all elements with a `lang` attribute value starting with `en`.
-`[attribute^=value]` | `a[href^="https"]`            | Selects every `<a>` element whose `href` attribute value begins with `https`.
-`[attribute$=value]` | `a[href$=".pdf"]`             | Selects every `<a>` element whose `href` attribute value ends with `.pdf`.
-`[attribute*=value]` | `a[href*="sometext"]`         | Selects every `<a>` element whose `href` attribute value contains the substring `sometext`.
-`:not(sel, sel)`     | `:not(.some-class, #some-id)` | Selects elements that do not have class `some-class` and ID `some-id`.
-`:is(sel, sel)`      | `:is(div, .some-class)`       | Selects elements that are not `<div>` and do not have class `some-class`. The alias `:matches` is allowed as well.
-`:has(> sel, + sel)` | `:has(> div, + p)`            | Selects elements that have a direct child that is a `<div>` or that have sibling of `<p>` immediately following.
-`:root`              | `:root`                       | Selects the root element.
+Selector                        | Example                       | Description
+------------------------------- | ----------------------------- | -----------
+`Element`                       | `div`                         | Select the `<div>` element (will be under the default namespace if defined for XHTML).
+`Element, Element`              | `div, h1`                     | Select the `<div>` element and the `<h1>` element.
+`Element Element`               | `div p`                       | Select all `<p>` elements inside `<div>` elements.
+`Element>Element`               | `div > p`                     | Select all `<p>` elements where the parent is a `<div>` element.
+`Element+Element`               | `div + p`                     | Select all `<p>` elements that are placed immediately after `<div>` elements.
+`Element~Element`               | `p ~ ul`                      | Select every `<ul>` element that is preceded by a `<p>` element.
+`namespace|Element`             | `svg|circle`                  | Select the `<circle>` element which also has the namespace `svg`.
+`*|Element`                     | `*|div`                       | Select the `<div>` element with or without a namespace.
+`namespace|*`                   | `svg|*`                       | Select any element with the namespace `svg`.
+`|Element`                      | `|div`                        | Select `<div>` elements without a namespace.
+`|*`                            | `|*`                          | Select any element without a namespace.
+`*|*`                           | `*|*`                         | Select all elements with any or no namespace.
+`*`                             | `*`                           | Select all elements. If a default namespace is defined, it will be any element under the default namespace.
+`[attribute]`                   | `[target]`                    | Selects all elements with a `target` attribute.
+`[ns|attribute]`                | `[xlink|href]`                | Selects elements with the attribute `href` and the namespace `xlink` (assuming it has been configured in the `namespaces` option).
+`[*|attribute]`                 | `[*|name]`                    | Selects any element with a `name` attribute that has a namespace or not.
+`[|attribute]`                  | `[|name]`                     | Selects any element with a `name` attribute. `[|name]` is equivalent to `[name]`.
+`[attribute=value]`             | `[target=_blank]`             | Selects all attributes with `target="_blank"`.
+`[attribute~=value]`            | `[title~=flower]`             | Selects all elements with a `title` attribute containing the word `flower`.
+`[attribute|=value]`            | `[lang|=en]`                  | Selects all elements with a `lang` attribute value starting with `en`.
+`[attribute^=value]`            | `a[href^="https"]`            | Selects every `<a>` element whose `href` attribute value begins with `https`.
+`[attribute$=value]`            | `a[href$=".pdf"]`             | Selects every `<a>` element whose `href` attribute value ends with `.pdf`.
+`[attribute*=value]`            | `a[href*="sometext"]`         | Selects every `<a>` element whose `href` attribute value contains the substring `sometext`.
+`:not(sel, sel)`                | `:not(.some-class, #some-id)` | Selects elements that do not have class `some-class` and ID `some-id`.
+`:is(sel, sel)`                 | `:is(div, .some-class)`       | Selects elements that are not `<div>` and do not have class `some-class`. The alias `:matches` is allowed as well. In CSS4 `:where` is like `:is` except specificity is always zero. PySpelling doesn't care about specificity, so `:where` is exactly like `:is`.
+`:has(> sel, + sel)`            | `:has(> div, + p)`            | Selects elements that have a direct child that is a `<div>` or that have sibling of `<p>` immediately following.
+`:first-child`                  | `p:first-child`               | Selects every `<p>` element that is the first child of its parent.
+`:last-child`                   | `p:last-child`                | Selects every `<p>` element that is the last child of its parent.
+`:first-of-type`                | `p:first-of-type`             | Selects every `<p>` element that is the first `<p>` element of its parent.
+`:last-of-type`                 | `p:last-of-type`              | Selects every `<p>` element that is the last `<p>` element of its parent.
+`:only-child`                   | `p:only-child`                | Selects every `<p>` element that is the only child of its parent.
+`:only-of-type`                 | `p:only-of-type`              | Selects every `<p>` element that is the only `<p>` element of its parent.
+`:nth-child(an+b [of S]?)`      | `p:nth-child(2)`              | Selects every `<p>` element that is the second child of its parent. Please see CSS specification for more info on format.
+`:nth-last-child(an+b [of S]?)` | `p:nth-last-child(2)`         | Selects every `<p>` element that is the second child of its parent, counting from the last child. Please see CSS specification for more info on format.
+`:nth-of-type(an+b)`            | `p:nth-of-type(2)`            | Selects every `<p>` element that is the second `<p>` element of its parent. Please see CSS specification for more info on format.
+`:nth-last-of-type(an+b)`       | `p:nth-last-of-type(2)`       | Selects every `<p>` element that is the second `<p>` element of its parent, counting from the last child. Please see CSS specification for more info on format.
+`:root`                         | `:root`                       | Selects the root element. In HTML, this is usually the `<html>` element.
+`:empty`                        | `p:empty`                     | Selects every `<p>` element that has no children and either no text. Whitespace and comments are ignored.
 
-!!! new "New 2.1.0"
-    Support for `div p`, `div>p`, `div+p`, `div~p`, `:is()`, `:has()` and `:root`.
+!!! new "New"
+    Support for `div p`, `div>p`, `div+p`, `div~p`, `:is()`, `:has()` and `:root` was added in 2.1.0.
 
-!!! warning ":has()"
-    `:has()` implementation is experimental and may change. There are currently no reference implementation available in any browsers, so current implementation is based on our best interpretation.
+    Support for `:nth-*`, `:first-*`, `:last-*`, `:only-*`, and `:empty` was added in 2.2.0.
+
+!!! warning "Experimental Selectors"
+    `:has()` implementation is experimental and may change. There are currently no reference implementation available in any browsers, not to mention the CSS4 specifications have not been finalized, so current implementation is based on our best interpretation.
+
+    Recent addition of `:nth-*`, `:first-*`, `:last-*`, `:only-*`, is experimental. It has been implemented to the best of our understanding, especially `of S` support. Any issues with the should be reported.
 
 ## Options
 

--- a/docs/src/markdown/filters/xml.md
+++ b/docs/src/markdown/filters/xml.md
@@ -83,7 +83,7 @@ Selector                        | Example                       | Description
 !!! warning "Experimental Selectors"
     `:has()` implementation is experimental and may change. There are currently no reference implementation available in any browsers, not to mention the CSS4 specifications have not been finalized, so current implementation is based on our best interpretation.
 
-    Recent addition of `:nth-*`, `:first-*`, `:last-*`, `:only-*`, is experimental. It has been implemented to the best of our understanding, especially `of S` support. Any issues with the should be reported.
+    Recent addition of `:nth-*`, `:first-*`, `:last-*`, and `:only-*`, is experimental. It has been implemented to the best of our understanding, especially `of S` support. Any issues with the should be reported.
 
 ## Options
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ edit_uri: tree/master/docs/src/markdown
 site_description: Python spell checker.
 copyright: |
   Copyright &copy; 2017 - 2018 <a href="https://github.com/facelessuser">Isaac Muse</a>
-  <br><span class="md-footer-custom-text">emoji provided free by </span><a href="http://www.emojione.com">EmojiOne</a>
+  <br><span class="md-footer-custom-text">emoji provided free by <a href="http://www.emojione.com">EmojiOne</a></span>
 
 docs_dir: docs/src/markdown
 theme:

--- a/pyspelling/__meta__.py
+++ b/pyspelling/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(2, 2, 1, ".dev")
+__version_info__ = Version(2, 2, 1, "final")
 __version__ = __version_info__._get_canonical()

--- a/pyspelling/__meta__.py
+++ b/pyspelling/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(2, 1, 1, "final")
+__version_info__ = Version(2, 2, 1, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/pyspelling/filters/xml.py
+++ b/pyspelling/filters/xml.py
@@ -201,7 +201,7 @@ class XmlFilter(filters.Filter):
                         attributes.append((html.unescape(value), sel))
 
             # Walk children
-            for child in list(tree):
+            for child in tree.children:
                 string = str(child).strip()
                 is_comment = isinstance(child, bs4.Comment)
                 if isinstance(child, bs4.element.Tag):

--- a/pyspelling/util/css_selectors.py
+++ b/pyspelling/util/css_selectors.py
@@ -794,40 +794,42 @@ class SelectorMatcher:
             count_incr = 1
             factor = -1 if last else 1
             index = len(parent.contents) - 1 if last else 0
-
-            # Abort if our nth index is out of bounds and only getting further out of bounds as we increment.
-            # Otherwise, increment to try to get in bounds.
             idx = last_idx = a * count + b if var else a
-            while idx < 1 or idx > last_index:
-                diff_low = 0 - idx
-                if idx < 0:
-                    count += count_incr
-                    idx = last_idx = a * count + b if var else a
-                    diff = 0 - idx
-                    if diff > diff_low:
-                        break
-                    diff_low = diff
-                diff_high = idx - last_index
-                if idx > last_index:
-                    count += count_incr
-                    idx = last_idx = a * count + b if var else a
-                    diff = idx - last_index
-                    if diff > diff_high:
-                        break
-                    diff_high = diff
 
-            # If a < 0, our count is working backwards, so floor the index by increasing the count.
-            # Find the count that yields the lowest, in bound value and use that.
-            # Lastly reverse count increment so that we'll increase our index.
-            lowest = count
-            if a < 0:
-                while idx >= 1:
-                    lowest = count
-                    count += count_incr
-                    idx = last_idx = a * count + b if var else a
-                count_incr = -1
-            count = lowest
-            idx = last_idx = a * count + b if var else a
+            # We can only adjust bounds within a variable index
+            if var:
+                # Abort if our nth index is out of bounds and only getting further out of bounds as we increment.
+                # Otherwise, increment to try to get in bounds.
+                while idx < 1 or idx > last_index:
+                    diff_low = 0 - idx
+                    if idx < 0:
+                        count += count_incr
+                        idx = last_idx = a * count + b if var else a
+                        diff = 0 - idx
+                        if diff >= diff_low:
+                            break
+                        diff_low = diff
+                    diff_high = idx - last_index
+                    if idx > last_index:
+                        count += count_incr
+                        idx = last_idx = a * count + b if var else a
+                        diff = idx - last_index
+                        if diff >= diff_high:
+                            break
+                        diff_high = diff
+
+                # If a < 0, our count is working backwards, so floor the index by increasing the count.
+                # Find the count that yields the lowest, in bound value and use that.
+                # Lastly reverse count increment so that we'll increase our index.
+                lowest = count
+                if a < 0:
+                    while idx >= 1:
+                        lowest = count
+                        count += count_incr
+                        idx = last_idx = a * count + b if var else a
+                    count_incr = -1
+                count = lowest
+                idx = last_idx = a * count + b if var else a
 
             # Evaluate elements while our calculated nth index is still in range
             while 1 <= idx <= last_index:

--- a/pyspelling/util/css_selectors.py
+++ b/pyspelling/util/css_selectors.py
@@ -787,15 +787,52 @@ class SelectorMatcher:
             last = n.last
             last_index = len(parent.contents) - 1
             relative_index = 0
-            factor = -1 if last else 1
-            index = len(parent.contents) - 1 if last else 0
             a = n.a
             b = n.b
             var = n.n
             count = 0
+            count_incr = 1
+            factor = -1 if last else 1
+            index = len(parent.contents) - 1 if last else 0
+
+            # Abort if our nth index is out of bounds and only getting further out of bounds as we increment.
+            # Otherwise, increment to try to get in bounds.
             idx = last_idx = a * count + b if var else a
-            while 0 <= idx <= last_index:
+            while idx < 1 or idx > last_index:
+                diff_low = 0 - idx
+                if idx < 0:
+                    count += count_incr
+                    idx = last_idx = a * count + b if var else a
+                    diff = 0 - idx
+                    if diff > diff_low:
+                        break
+                    diff_low = diff
+                diff_high = idx - last_index
+                if idx > last_index:
+                    count += count_incr
+                    idx = last_idx = a * count + b if var else a
+                    diff = idx - last_index
+                    if diff > diff_high:
+                        break
+                    diff_high = diff
+
+            # If a < 0, our count is working backwards, so floor the index by increasing the count.
+            # Find the count that yields the lowest, in bound value and use that.
+            # Lastly reverse count increment so that we'll increase our index.
+            lowest = count
+            if a < 0:
+                while idx >= 1:
+                    lowest = count
+                    count += count_incr
+                    idx = last_idx = a * count + b if var else a
+                count_incr = -1
+            count = lowest
+            idx = last_idx = a * count + b if var else a
+
+            # Evaluate elements while our calculated nth index is still in range
+            while 1 <= idx <= last_index:
                 child = None
+                # Evaluate while our child index is still range.
                 while 0 <= index <= last_index:
                     child = parent.contents[index]
                     index += factor
@@ -818,13 +855,15 @@ class SelectorMatcher:
                 if child is el:
                     break
                 last_idx = idx
-                count += 1
+                count += count_incr
+                if count < 0:
+                    # Count is counting down and has now ventured into invalid territory.
+                    break
                 idx = a * count + b if var else a
                 if last_idx == idx:
                     break
             if not matched:
                 break
-
         return matched
 
     def has_child(self, el):

--- a/pyspelling/util/css_selectors.py
+++ b/pyspelling/util/css_selectors.py
@@ -560,22 +560,18 @@ class SelectorMatcher:
             if parent:
                 found = self.match_selectors(parent, [relation])
         elif relation.rel_type == REL_SIBLING:
-            parent = el.parent
-            sibling = el.previous_element
+            sibling = el.previous_sibling
             while not found and sibling:
                 if not isinstance(sibling, TAG):
-                    sibling = sibling.previous_element
+                    sibling = sibling.previous_sibling
                     continue
-                if sibling.parent is not parent:
-                    break
                 found = self.match_selectors(sibling, [relation])
-                sibling = sibling.previous_element
+                sibling = sibling.previous_sibling
         elif relation.rel_type == REL_CLOSE_SIBLING:
-            parent = el.parent
-            sibling = el.previous_element
+            sibling = el.previous_sibling
             while sibling and not isinstance(sibling, TAG):
-                sibling = sibling.previous_element
-            if sibling and sibling.parent is parent and isinstance(sibling, TAG):
+                sibling = sibling.previous_sibling
+            if sibling and isinstance(sibling, TAG):
                 found = self.match_selectors(sibling, [relation])
         return found
 
@@ -583,7 +579,7 @@ class SelectorMatcher:
         """Match future child."""
 
         match = False
-        for child in list(parent):
+        for child in parent.children:
             if not isinstance(child, TAG):
                 continue
             match = self.match_selectors(child, [relation])
@@ -602,22 +598,18 @@ class SelectorMatcher:
         elif relation.rel_type == REL_HAS_CLOSE_PARENT:
             found = self.match_future_child(el, relation)
         elif relation.rel_type == REL_HAS_SIBLING:
-            parent = el.parent
-            sibling = el.next_element
+            sibling = el.next_sibling
             while not found and sibling:
                 if not isinstance(sibling, TAG):
-                    sibling = sibling.next_element
+                    sibling = sibling.next_sibling
                     continue
-                if sibling.parent is not parent:
-                    break
                 found = self.match_selectors(sibling, [relation])
-                sibling = sibling.next_element
+                sibling = sibling.next_sibling
         elif relation.rel_type == REL_HAS_CLOSE_SIBLING:
-            parent = el.parent
-            sibling = el.next_element
+            sibling = el.next_sibling
             while sibling and not isinstance(sibling, TAG):
-                sibling = sibling.next_element
-            if sibling and sibling.parent is parent and isinstance(sibling, TAG):
+                sibling = sibling.next_sibling
+            if sibling and isinstance(sibling, TAG):
                 found = self.match_selectors(sibling, [relation])
         return found
 

--- a/pyspelling/util/css_selectors.py
+++ b/pyspelling/util/css_selectors.py
@@ -579,12 +579,10 @@ class SelectorMatcher:
         """Match future child."""
 
         match = False
-        for child in parent.children:
+        for child in (parent.descendants if recursive else parent.children):
             if not isinstance(child, TAG):
                 continue
             match = self.match_selectors(child, [relation])
-            if not match and recursive:
-                match = self.match_future_child(child, relation, recursive)
             if match:
                 break
         return match

--- a/pyspelling/util/css_selectors.py
+++ b/pyspelling/util/css_selectors.py
@@ -737,6 +737,14 @@ class SelectorMatcher:
         parent = el.parent
         return parent and not parent.parent
 
+    def match_nth_tag_type(self, el, child):
+        """Match tag type for `nth` matches."""
+
+        return(
+            (child.name == (lower(el.name) if not self.is_xml() else el.name)) and
+            (self.supports_namespaces() and self.get_namespace(child) == self.get_namespace(el))
+        )
+
     def match_nth(self, el, nth):
         """Match `nth` elements."""
 
@@ -765,7 +773,7 @@ class SelectorMatcher:
                     if not isinstance(child, TAG):
                         continue
                     # Need to handle namespace
-                    if n.type and child.name != (lower(el.name) if not self.is_xml() else el.name):
+                    if n.type and not self.match_nth_tag_type(el, child):
                         continue
                     relative_index += 1
                     if relative_index == idx:

--- a/tests/filters/test_html.py
+++ b/tests/filters/test_html.py
@@ -324,6 +324,60 @@ class TestHtml5NthSelectors(util.PluginTestCase):
             ]
         )
 
+    def test_css_nth_odd(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'p:nth-child(odd)'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'bbbb', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'hhhh', 'jjjj', 'llll'
+            ]
+        )
+
+    def test_css_nth_even(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'p:nth-child(even)'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'aaaa', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'iiii', 'kkkk', 'llll'
+            ]
+        )
+
     def test_css_nth_child(self):
         """Test HTML."""
 

--- a/tests/filters/test_html.py
+++ b/tests/filters/test_html.py
@@ -668,6 +668,33 @@ class TestHtml5NthSelectors(util.PluginTestCase):
             ]
         )
 
+    def test_css_nth_child_bad(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'p:nth-child(-2)'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'aaaa', 'bbbb', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'hhhh', 'iiii', 'jjjj', 'kkkk', 'llll'
+            ]
+        )
+
     def test_css_nth_child1(self):
         """Test HTML."""
 

--- a/tests/filters/test_html.py
+++ b/tests/filters/test_html.py
@@ -448,6 +448,57 @@ class TestHtml5NthOfSelectors(util.PluginTestCase):
             ]
         )
 
+    def test_css_child_of_s_vs_schild(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - ':nth-child(-n+3 of p)'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'iiii', 'jjjj', 'kkkk', 'llll'
+            ]
+        )
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'p:nth-child(-n+3)'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'hhhh', 'iiii', 'jjjj', 'kkkk', 'llll'
+            ]
+        )
+
 
 class TestHtml5NthSelectors(util.PluginTestCase):
     """Test CSS `nth` selectors."""
@@ -617,7 +668,61 @@ class TestHtml5NthSelectors(util.PluginTestCase):
             ]
         )
 
-    def test_css_nth_child(self):
+    def test_css_nth_child1(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'p:nth-child(2)'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'aaaa', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'hhhh', 'iiii', 'jjjj', 'kkkk', 'llll'
+            ]
+        )
+
+    def test_css_nth_child2(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'p:nth-child(9n - 1)'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'aaaa', 'bbbb', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'iiii', 'jjjj', 'kkkk', 'llll'
+            ]
+        )
+
+    def test_css_nth_child3(self):
         """Test HTML."""
 
         config = self.dedent(

--- a/tests/filters/test_html.py
+++ b/tests/filters/test_html.py
@@ -237,6 +237,94 @@ class TestHtml5AttrNamespace(util.PluginTestCase):
         self.assert_spellcheck('.html5.yml', ['cccc'])
 
 
+class TestHtml5OnlySelectors(util.PluginTestCase):
+    """Test CSS `nth` selectors."""
+
+    def setup_fs(self):
+        """Setup file system."""
+
+        template = self.dedent(
+            """
+            <!DOCTYPE html>
+            <html>
+            <head>
+              <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+            </head>
+            <body>
+            <div>
+                <p>aaaa</p>
+            </div>
+            <span>bbbb</span>
+            <span>cccc</span>
+            <p>dddd</p>
+            <span>eeee</span>
+            <span>ffff</span>
+            <div>
+                <p>gggg</p>
+                <p>hhhh</p>
+            </div>
+            </body>
+            </html>
+            """
+        )
+
+        self.mktemp('test.txt', template, 'utf-8')
+
+    def test_css_only_child(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'p:only-child'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'bbbb', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'hhhh'
+            ]
+        )
+
+    def test_css_only_type(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'p:only-of-type'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'bbbb', 'cccc', 'eeee', 'ffff', 'gggg', 'hhhh'
+            ]
+        )
+
+
 class TestHtml5NthSelectors(util.PluginTestCase):
     """Test CSS `nth` selectors."""
 
@@ -321,6 +409,33 @@ class TestHtml5NthSelectors(util.PluginTestCase):
         self.assert_spellcheck(
             '.html5.yml', [
                 'bbbb', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'iiii', 'kkkk', 'llll'
+            ]
+        )
+
+    def test_css_nth_complex_type(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - ':nth-of-type(2n + 1):is(p, span)'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'bbbb', 'dddd', 'ffff', 'iiii', 'kkkk', 'llll'
             ]
         )
 

--- a/tests/filters/test_html.py
+++ b/tests/filters/test_html.py
@@ -237,6 +237,256 @@ class TestHtml5AttrNamespace(util.PluginTestCase):
         self.assert_spellcheck('.html5.yml', ['cccc'])
 
 
+class TestHtml5NthSelectors(util.PluginTestCase):
+    """Test CSS `nth` selectors."""
+
+    def setup_fs(self):
+        """Setup file system."""
+
+        template = self.dedent(
+            """
+            <!DOCTYPE html>
+            <html>
+            <head>
+              <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+            </head>
+            <body>
+            <p>aaaa</p>
+            <p>bbbb</p>
+            <span>cccc</span>
+            <span>dddd</span>
+            <span>eeee</span>
+            <span>ffff</span>
+            <span>gggg</span>
+            <p>hhhh</p>
+            <p>iiii</p>
+            <p>jjjj</p>
+            <p>kkkk</p>
+            <span>llll</span>
+            </body>
+            </html>
+            """
+        )
+
+        self.mktemp('test.txt', template, 'utf-8')
+
+    def test_css_first_child(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'p:first-child'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'bbbb', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'hhhh', 'iiii', 'jjjj', 'kkkk', 'llll'
+            ]
+        )
+
+    def test_css_nth_type(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'p:nth-of-type(2n + 1)'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'bbbb', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'iiii', 'kkkk', 'llll'
+            ]
+        )
+
+    def test_css_nth_child(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'p:nth-child(2n + 1)'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'bbbb', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'hhhh', 'jjjj', 'llll'
+            ]
+        )
+
+    def test_css_nth_last_type(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'p:nth-last-of-type(2n + 1)'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'aaaa', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'jjjj', 'hhhh', 'llll'
+            ]
+        )
+
+    def test_css_nth_last_child(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'p:nth-last-child(2n + 1)'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'aaaa', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'iiii', 'kkkk', 'llll'
+            ]
+        )
+
+    def test_css_first_type(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'span:first-of-type'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'aaaa', 'bbbb', 'dddd', 'eeee', 'ffff', 'gggg', 'hhhh', 'iiii', 'jjjj', 'kkkk', 'llll'
+            ]
+        )
+
+    def test_css_last_child(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'span:last-child'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'aaaa', 'bbbb', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'hhhh', 'iiii', 'jjjj', 'kkkk'
+            ]
+        )
+
+    def test_css_last_type(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'p:last-of-type'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'aaaa', 'bbbb', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg', 'hhhh', 'iiii', 'jjjj', 'llll'
+            ]
+        )
+
+
 class TestHtml5AdvancedSelectors(util.PluginTestCase):
     """Test advanced CSS selectors."""
 

--- a/tests/filters/test_html.py
+++ b/tests/filters/test_html.py
@@ -237,6 +237,69 @@ class TestHtml5AttrNamespace(util.PluginTestCase):
         self.assert_spellcheck('.html5.yml', ['cccc'])
 
 
+class TestHtml5EmptySelectors(util.PluginTestCase):
+    """Test CSS empty selectors."""
+
+    def setup_fs(self):
+        """Setup file system."""
+
+        template = self.dedent(
+            """
+            <!DOCTYPE html>
+            <html>
+            <head>
+              <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+            </head>
+            <body>
+            <span>aaaa</span>
+            <span> <!-- comment --> </span>
+            <span>bbbb</span>
+            <span>cccc</span>
+            <span>  </span>
+            <p>dddd</p>
+            <span>eeee</span>
+            <span>ffff</span>
+            <div>
+                <p>gggg</p>
+                <span>
+                </span>
+                <p>hhhh</p>
+            </div>
+            </body>
+            </html>
+            """
+        )
+
+        self.mktemp('test.txt', template, 'utf-8')
+
+    def test_css_empty(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - 'span:empty + *'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'aaaa', 'cccc', 'eeee', 'ffff', 'gggg'
+            ]
+        )
+
+
 class TestHtml5OnlySelectors(util.PluginTestCase):
     """Test CSS `nth` selectors."""
 

--- a/tests/filters/test_html.py
+++ b/tests/filters/test_html.py
@@ -388,6 +388,67 @@ class TestHtml5OnlySelectors(util.PluginTestCase):
         )
 
 
+class TestHtml5NthOfSelectors(util.PluginTestCase):
+    """Test CSS `nth` selectors."""
+
+    def setup_fs(self):
+        """Setup file system."""
+
+        template = self.dedent(
+            """
+            <!DOCTYPE html>
+            <html>
+            <head>
+              <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+            </head>
+            <body>
+            <p>aaaa</p>
+            <p>bbbb</p>
+            <span class="test">cccc</span>
+            <span>dddd</span>
+            <span class="test">eeee</span>
+            <span>ffff</span>
+            <span class="test">gggg</span>
+            <p>hhhh</p>
+            <p class="test">iiii</p>
+            <p>jjjj</p>
+            <p class="test">kkkk</p>
+            <span>llll</span>
+            </body>
+            </html>
+            """
+        )
+
+        self.mktemp('test.txt', template, 'utf-8')
+
+    def test_css_child_of_s(self):
+        """Test HTML."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: html_css
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.html:
+                  mode: html5
+                  ignores:
+                  - ':nth-child(2n + 1 of :is(p, span).test)'
+            """
+        ).format(self.tempdir)
+        self.mktemp('.html5.yml', config, 'utf-8')
+        self.assert_spellcheck(
+            '.html5.yml', [
+                'aaaa', 'bbbb', 'dddd', 'eeee', 'ffff', 'hhhh', 'iiii', 'jjjj', 'llll'
+            ]
+        )
+
+
 class TestHtml5NthSelectors(util.PluginTestCase):
     """Test CSS `nth` selectors."""
 


### PR DESCRIPTION
Closes #58

Add support for CSS4 selectors: `:first-child`, `:last-child`, `:only-child`, `:first-of-type`, `:last-of-type`, `:only-of-type`, `:nth-child(an+b [of S]?)`, `:nth-last-child(an+b [of S]?)`, `:nth-of-type(an+b)`, and `:nth-last-of-type(an+b)`. (#58)

Also add support for `:empty`.

This should finally cover all the desired CSS additions that I initially wanted. I don't really see a need for most of the others to be honest, and some cannot be implemented in our offline environment anyways as it doesn't make sense.