### PR TITLE
Parse XML and HTML without recursion

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -3,6 +3,7 @@
 ## 2.3.0
 
 - **NEW**: Support new `wcmatch` glob feature flags and upgrade to `wcmatch` 4.0.
+- **FIX**: Don't use recursion when parsing XML or HTML documents.
 
 ## 2.2.6
 

--- a/docs/src/markdown/filters/html.md
+++ b/docs/src/markdown/filters/html.md
@@ -68,5 +68,5 @@ Category         | Description
 `html-comment`   | Text captured from HTML comments.
 
 --8<--
-refs.md
+refs.txt
 --8<--

--- a/docs/src/markdown/filters/xml.md
+++ b/docs/src/markdown/filters/xml.md
@@ -62,5 +62,5 @@ Category         | Description
 `xml-comment`   | Text captured from XML comments.
 
 --8<--
-refs.md
+refs.txt
 --8<--

--- a/pyspelling/filters/html.py
+++ b/pyspelling/filters/html.py
@@ -6,7 +6,6 @@ Detect encoding from HTML header.
 from __future__ import unicode_literals
 import re
 import codecs
-import html
 import soupsieve as sv
 from . import xml
 from collections import deque
@@ -109,15 +108,15 @@ class HtmlFilter(xml.XmlFilter):
         else:
             return [c for c in el.attrs.get('class', '').strip().split(' ') if c]
 
-    def store_blocks(self, el, blocks, text, force_root):
-        """Store the text as desired."""
+    def format_blocks(self):
+        """Format the text as for a block."""
 
-        if force_root or el.parent is None or self.is_break_tag(el):
-            content = html.unescape(''.join(text))
+        block_text = []
+        for el, text in self._block_text.items():
+            content = ''.join(text)
             if content:
-                blocks.append((content, self.construct_selector(el)))
-            text = []
-        return text
+                block_text.append((content, self.construct_selector(el)))
+        return block_text
 
     def construct_selector(self, el, attr=''):
         """Construct an selector for context."""

--- a/pyspelling/filters/odf.py
+++ b/pyspelling/filters/odf.py
@@ -92,7 +92,7 @@ class OdfFilter(xml.XmlFilter):
                 text = b.read().decode(encoding)
             yield text, filename, encoding
 
-    def content_break(self, el):
+    def is_break_tag(self, el):
         """Break on specified boundaries."""
 
         should_break = False
@@ -115,7 +115,7 @@ class OdfFilter(xml.XmlFilter):
             self.soft_break(el, text)
             content = ''.join(text)
             if content:
-                block_text.append((content, self.construct_selector(el)))
+                block_text.append((content, self.additional_context + self.construct_selector(el)))
         return block_text
 
     def extract_tag_metadata(self, el):

--- a/pyspelling/filters/odf.py
+++ b/pyspelling/filters/odf.py
@@ -6,7 +6,6 @@ Parse the `text` namespace in `content.xml` in ODF zip files.
 from __future__ import unicode_literals
 import zipfile
 import io
-import html
 import bs4
 import codecs
 from .. import filters
@@ -108,17 +107,16 @@ class OdfFilter(xml.XmlFilter):
         if el.name == 'p' and el.namespace and el.namespace == self.namespaces["text"]:
             text.append('\n')
 
-    def store_blocks(self, el, blocks, text, force_root):
-        """Store the text as desired."""
+    def format_blocks(self):
+        """Format the text as for a block."""
 
-        self.soft_break(el, text)
-
-        if force_root or el.parent is None or self.content_break(el):
-            content = html.unescape(''.join(text))
+        block_text = []
+        for el, text in self._block_text.items():
+            self.soft_break(el, text)
+            content = ''.join(text)
             if content:
-                blocks.append((content, self.additional_context + self.construct_selector(el)))
-            text = []
-        return text
+                block_text.append((content, self.construct_selector(el)))
+        return block_text
 
     def extract_tag_metadata(self, el):
         """Extract meta data."""
@@ -152,7 +150,7 @@ class OdfFilter(xml.XmlFilter):
         content = []
         soup = bs4.BeautifulSoup(text, self.parser)
         soup = self.get_sub_node(soup)
-        blocks, attributes, comments = self.to_text(soup, force_root=not isinstance(soup, bs4.BeautifulSoup))
+        blocks, attributes, comments = self.to_text(soup)
         if self.comments:
             for c, desc in comments:
                 content.append(filters.SourceText(c, context + ': ' + desc, encoding, self.type + 'comment'))

--- a/pyspelling/filters/ooxml.py
+++ b/pyspelling/filters/ooxml.py
@@ -123,7 +123,7 @@ class OoxmlFilter(odf.OdfFilter):
         if self.type == 'pptx' and el.namespace == self.namespaces['a'] and el.name == 'p':
             text.append('\n')
 
-    def content_break(self, el):
+    def is_break_tag(self, el):
         """Break on specified boundaries."""
 
         should_break = False

--- a/pyspelling/filters/xml.py
+++ b/pyspelling/filters/xml.py
@@ -168,10 +168,13 @@ class XmlFilter(filters.Filter):
     def get_last_descendant(self, node):
         """Get the last descendant."""
 
-        last_child = node
-        while isinstance(last_child, bs4.Tag) and last_child.contents:
-            last_child = last_child.contents[-1]
-        last_descendant = last_child.next_element
+        if node.next_sibling is not None:
+            last_descendant = node.next_sibling
+        else:
+            last_child = node
+            while isinstance(last_child, bs4.Tag) and last_child.contents:
+                last_child = last_child.contents[-1]
+            last_descendant = last_child.next_element
 
         return last_descendant
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py34,py35,py36,py37, lint
+    py34,py35,py36,py37,lint
 
 [testenv]
 passenv = LANG TOX_SPELL_PATH TOX_SPELL_REQUIRE


### PR DESCRIPTION
Recursion can sometimes cause issues if too many recursive calls get called. While this hasn't been experienced in this project by me, it is possible it could occur, so by removing recursion, this should work in deeply nested documents. Though there may be a little slowness in some cases for extremely deep nested documents.

Fixes #72