### PR TITLE
Support new wcmatch 4.0 glob flags

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.0
+
+- **NEW**: Support new `wcmatch` glob feature flags and upgrade to `wcmatch` 4.0.
+
 ## 2.2.6
 
 - **FIX**: Require `wcmatch` 3.0 for `glob` related fixes.

--- a/pyspelling/filters/odf.py
+++ b/pyspelling/filters/odf.py
@@ -24,7 +24,7 @@ MIMEMAP = {
 class OdfFilter(xml.XmlFilter):
     """Spelling Python."""
 
-    FLAGS = glob.G | glob.N | glob.B | glob.S
+    FLAGS = glob.G | glob.N | glob.B | glob.S | glob.O
 
     default_capture = ['text|*']
 

--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -2,6 +2,6 @@ beautifulsoup4
 soupsieve>=1.8
 markdown
 pyyaml
-wcmatch>=3.0
+wcmatch>=4.0
 lxml
 html5lib


### PR DESCRIPTION
Utilize NODIR flag internally for avoiding directories, also add support
for NEGATEALL and MATCHBASE flags from yaml file. Also accept SPLIT and NODIR even though we force them on internally anyways.