### PR TITLE
Disable aspell fitlers by default unless explicitly enabled

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -2,7 +2,7 @@
 
 ## 2.4.0
 
-- **NEW**: Disable Aspell filters by default. Users must explicitly set the `mode` parameter to a filter mode under `aspell` option if they'd like to enable it.
+- **NEW**: Disable Aspell filters by default. Users must explicitly set the `mode` parameter under the `aspell` option to enable default Aspell filters.
 - **FIX**: Throw an exception with a helpful message if no configuration is found or there is some other issue.
 
 ## 2.3.1

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## Current
+## 2.4.0
 
+- **NEW**: Disable Aspell filters by default. Users must explicitly set the `mode` parameter to a filter mode under `aspell` option if they'd like to enable it.
 - **FIX**: Throw an exception with a helpful message if no configuration is found or there is some other issue.
 
 ## 2.3.1

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -138,6 +138,11 @@ index d0cccb3..4258f85 100644
 
 PySpelling is also tested on Aspell 0.60+ (which is recommended), but should also work on the 0.50 series. 0.60+ is recommended as spell checking is better in the 0.60 series.
 
+PySpelling disables all native Aspell filters by default. If you need to enable Aspell's native filters, you can do so via Aspell's builtin options. For more information, see [Aspell configuration options](./configuration.md#spell-checker-options).
+
+!!! new "New in 2.4.0"
+    Starting in 2.4.0, PySpelling ensures filters that are native to the spell checker are disabled by default.
+
 ## Usage in Linux
 
 Aspell and Hunspell is most likely available in your distro's package manager. You need to install both the spell checker and the dictionaries, or provide your own custom dictionaries. The option to build manually is always available as well. See your preferred spell checker's manual for more information on building manually.

--- a/pyspelling/__init__.py
+++ b/pyspelling/__init__.py
@@ -443,6 +443,9 @@ class Aspell(SpellChecker):
             'rem-texinfo-ignore', 'add-texinfo-ignore-env', 'rem-texinfo-ignore-env', 'filter'
         }
 
+        if 'mode' not in options:
+            options['mode'] = 'none'
+
         for k, v in options.items():
             if k in allowed:
                 key = ('-%s' if len(k) == 1 else '--%s') % k

--- a/pyspelling/__meta__.py
+++ b/pyspelling/__meta__.py
@@ -185,5 +185,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(2, 3, 1, "final")
+__version_info__ = Version(2, 4, 0, ".dev")
 __version__ = __version_info__._get_canonical()


### PR DESCRIPTION
Considering disabling Aspell default filters. A user would need to explicitly set it if they'd like it to be set to something.

I haven't decided whether we want to do this. The other option is maybe to note in the documentation that you can disable `Aspell` filters via:

```yml
aspell:
    mode: none
```
