### PR TITLE
Add tests for bad or no names and change some error types

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -3,8 +3,9 @@
 ## 2.4.0
 
 - **NEW**: Disable Aspell filters by default. Users must explicitly set the `mode` parameter under the `aspell` option to enable default Aspell filters.
-- **FIX**: Throw an exception with a helpful message if no configuration is found or there is some other issue.
-- **FIX**: Throw an exception with a helpful message when no tasks are found in the matrix or when no tasks match a given name or group.
+- **New**: Throw an exception with a message if no configuration is found or there is some other issue.
+- **New**: Throw an exception with a message when no tasks are found in the matrix or when no tasks match a given name or group.
+- **New**: Throw an exception with a message when a task is run but no files are found.
 
 ## 2.3.1
 

--- a/pyspelling/__init__.py
+++ b/pyspelling/__init__.py
@@ -614,11 +614,11 @@ def spellcheck(config_file, names=None, groups=None, binary='', checker='', sour
     if sources is None:
         sources = []
 
-    matrix = config.get('matrix', [])
+    matrix = config.get('matrix')
     preferred_checker = config.get('spellchecker', 'aspell')
-    if not matrix:
-        matrix = config.get('documents', [])
-        if matrix:
+    if matrix is None:
+        matrix = config.get('documents')
+        if matrix is not None:
             util.warn_deprecated("'documents' key in config is deprecated. 'matrix' should be used going forward.")
         else:
             raise KeyError(

--- a/pyspelling/__init__.py
+++ b/pyspelling/__init__.py
@@ -199,11 +199,10 @@ class SpellChecker:
                         err = self.get_error(e)
                         yield [filters.SourceText('', f, '', '', err)]
         if not found_something:
-            raise ValueError(
-                'None of the source targets from the configuration'
-                ' match any files:\n{}'.format('\n'.join(
-                    '- {}'.format(target) for target in targets
-                ))
+            raise RuntimeError(
+                'None of the source targets from the configuration match any files:\n{}'.format(
+                    '\n'.join('- {}'.format(target) for target in targets)
+                )
             )
 
     def setup_spellchecker(self, task):
@@ -622,7 +621,7 @@ def spellcheck(config_file, names=None, groups=None, binary='', checker='', sour
         if matrix:
             util.warn_deprecated("'documents' key in config is deprecated. 'matrix' should be used going forward.")
         else:
-            raise ValueError(
+            raise KeyError(
                 'Unable to find or load matrix from pyspelling'
                 ' configuration, for more'
                 ' details on configuration please read'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -142,7 +142,7 @@ class TestNameGroup(util.PluginTestCase):
             """
         ).format(temp=self.tempdir)
         self.mktemp('.nosource.yml', config, 'utf-8')
-        with self.assertRaises(ValueError) as excctxt:
+        with self.assertRaises(RuntimeError) as excctxt:
             self.assert_spellcheck('.nosource.yml', [])
         self.assertIn('test4.txt', str(excctxt.exception))
 
@@ -160,6 +160,31 @@ class TestNameGroup(util.PluginTestCase):
 
     def test_no_matrix(self):
         """Test a `ValueError` is raised if the configuration has no matrix."""
+
+        self.mktemp('.source.yml', "", 'utf-8')
+        with self.assertRaises(KeyError):
+            self.assert_spellcheck('.source.yml', [])
+
+    def test_bad_name(self):
+        """Test bad name."""
+
+        config = self.dedent(
+            """
+            matrix:
+            """
+        ).format(temp=self.tempdir)
+        self.mktemp('.source.yml', "", 'utf-8')
+        with self.assertRaises(ValueError):
+            self.assert_spellcheck('.source.yml', [], names=['name'])
+
+    def test_no_name(self):
+        """Test no name."""
+
+        config = self.dedent(
+            """
+            matrix:
+            """
+        ).format(temp=self.tempdir)
         self.mktemp('.source.yml', "", 'utf-8')
         with self.assertRaises(ValueError):
             self.assert_spellcheck('.source.yml', [])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -161,7 +161,13 @@ class TestNameGroup(util.PluginTestCase):
     def test_no_matrix(self):
         """Test a `ValueError` is raised if the configuration has no matrix."""
 
-        self.mktemp('.source.yml', "", 'utf-8')
+        config = self.dedent(
+            """
+            something:
+            """
+        )
+
+        self.mktemp('.source.yml', config, 'utf-8')
         with self.assertRaises(KeyError):
             self.assert_spellcheck('.source.yml', [])
 
@@ -172,7 +178,7 @@ class TestNameGroup(util.PluginTestCase):
             """
             matrix:
             """
-        ).format(temp=self.tempdir)
+        )
         self.mktemp('.source.yml', "", 'utf-8')
         with self.assertRaises(ValueError):
             self.assert_spellcheck('.source.yml', [], names=['name'])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -177,9 +177,10 @@ class TestNameGroup(util.PluginTestCase):
         config = self.dedent(
             """
             matrix:
+            - name: other
             """
         )
-        self.mktemp('.source.yml', "", 'utf-8')
+        self.mktemp('.source.yml', config, 'utf-8')
         with self.assertRaises(ValueError):
             self.assert_spellcheck('.source.yml', [], names=['name'])
 
@@ -190,7 +191,7 @@ class TestNameGroup(util.PluginTestCase):
             """
             matrix:
             """
-        ).format(temp=self.tempdir)
-        self.mktemp('.source.yml', "", 'utf-8')
+        )
+        self.mktemp('.source.yml', config, 'utf-8')
         with self.assertRaises(ValueError):
             self.assert_spellcheck('.source.yml', [])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -163,7 +163,7 @@ class TestNameGroup(util.PluginTestCase):
 
         config = self.dedent(
             """
-            something:
+            something: []
             """
         )
 
@@ -189,7 +189,7 @@ class TestNameGroup(util.PluginTestCase):
 
         config = self.dedent(
             """
-            matrix:
+            matrix: []
             """
         )
         self.mktemp('.source.yml', config, 'utf-8')


### PR DESCRIPTION
Use RuntimeError for when files are not found.
Change missing `matrix` error from ValueError to KeyError.
Also add tests for no name and bad names.