### PR TITLE
PR #86 errors if no files are found for a target.

### DIFF
--- a/docs/src/markdown/configuration.md
+++ b/docs/src/markdown/configuration.md
@@ -147,7 +147,7 @@ matrix:
 When processing the sources field it is expected to find at least
 one matching file. If no files are located it can be helpful to raise an error
 and this is the default behaviour. If it is not expected to always find a file
-then the expect\_match configuration can be used to surpress the error.
+then the `expect\_match` configuration can be used to suppress the error.
 
 ```yaml
 matrix:

--- a/docs/src/markdown/configuration.md
+++ b/docs/src/markdown/configuration.md
@@ -142,6 +142,24 @@ matrix:
   - pyspelling/**/*.py
 ```
 
+### Expect Match
+
+When processing the sources field it is expected to find at least
+one matching file. If no files are located it can be helpful to raise an error
+and this is the default behaviour. If it is not expected to always find a file
+then the expect\_match configuration can be used to surpress the error.
+
+```yaml
+matrix:
+- name: markdown
+  pipeline:
+  - pyspelling.filters.text
+  sources:
+  - '**/*.md'
+  expect_match: false
+  default_encoding: utf-8
+```
+
 ### Pipeline
 
 PySpelling allows you to define tasks that outline what kind of files you want to spell check, and then sends them down a pipeline that filters the content returning chunks of text with some associated context. Each chunk is sent down each step of the pipeline until it reaches the final step, the spell check step. Between filter steps, you can also insert flow control steps that allow you to have certain text chunks skip specific steps. All of this is done with [pipeline plugins](./pipeline.md).

--- a/pyspelling/__init__.py
+++ b/pyspelling/__init__.py
@@ -169,7 +169,7 @@ class SpellChecker:
     def compile_dictionary(self, lang, wordlists, output):
         """Compile user dictionary."""
 
-    def _walk_src(self, targets, flags, pipeline):
+    def _walk_src(self, targets, flags, pipeline, expect_glob_match):
         """Walk source and parse files."""
 
         found_something = False
@@ -198,7 +198,7 @@ class SpellChecker:
                     except Exception as e:
                         err = self.get_error(e)
                         yield [filters.SourceText('', f, '', '', err)]
-        if not found_something:
+        if not found_something and expect_glob_match:
             raise RuntimeError(
                 'None of the source targets from the configuration match any files:\n{}'.format(
                     '\n'.join('- {}'.format(target) for target in targets)
@@ -299,8 +299,9 @@ class SpellChecker:
         if not source_patterns:
             source_patterns = task.get('sources', [])
 
-        for sources in self._walk_src(source_patterns, glob_flags, self.pipeline_steps):
-
+        expect_glob_match = task.get('expect_glob_match', 'Y') == 'Y'
+        for sources in self._walk_src(source_patterns, glob_flags, self.pipeline_steps,
+                                      expect_glob_match,):
             if self.pipeline_steps is not None:
                 yield from self._spelling_pipeline(sources, options, personal_dict)
             else:

--- a/pyspelling/__init__.py
+++ b/pyspelling/__init__.py
@@ -169,7 +169,7 @@ class SpellChecker:
     def compile_dictionary(self, lang, wordlists, output):
         """Compile user dictionary."""
 
-    def _walk_src(self, targets, flags, pipeline, expect_glob_match):
+    def _walk_src(self, targets, flags, pipeline, expect_match):
         """Walk source and parse files."""
 
         found_something = False
@@ -198,7 +198,7 @@ class SpellChecker:
                     except Exception as e:
                         err = self.get_error(e)
                         yield [filters.SourceText('', f, '', '', err)]
-        if not found_something and expect_glob_match:
+        if not found_something and expect_match:
             raise RuntimeError(
                 'None of the source targets from the configuration match any files:\n{}'.format(
                     '\n'.join('- {}'.format(target) for target in targets)
@@ -299,9 +299,9 @@ class SpellChecker:
         if not source_patterns:
             source_patterns = task.get('sources', [])
 
-        expect_glob_match = task.get('expect_glob_match', 'Y') == 'Y'
+        expect_match = task.get('expect_match', True)
         for sources in self._walk_src(source_patterns, glob_flags, self.pipeline_steps,
-                                      expect_glob_match,):
+                                      expect_match,):
             if self.pipeline_steps is not None:
                 yield from self._spelling_pipeline(sources, options, personal_dict)
             else:


### PR DESCRIPTION
This is normally the desired behaviour but this change add a configuration
flag to avoid an error if desired so that a pyspelling configuration file can
be re-used even if not all file types are present.