### PR TITLE
Prepare for wcmatch 5.0

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.1
+
+- **FIX**: Add workaround for `wcmatch` version `5.0`.
+
 ## 2.5.0
 
 - **NEW**: Add `expect_match` option to prevent a rule from failing if it finds no matching files.

--- a/pyspelling/__init__.py
+++ b/pyspelling/__init__.py
@@ -6,10 +6,13 @@ from .__meta__ import __version__, __version_info__  # noqa: F401
 from . import flow_control
 from . import filters
 from wcmatch import glob
+import wcmatch
 import codecs
 from collections import namedtuple
 
 __all__ = ("spellcheck",)
+
+CASE_SUPPORT = wcmatch.__version_info__ >= (5, 0)
 
 
 class Results(namedtuple('Results', ['words', 'context', 'category', 'error'])):
@@ -27,8 +30,8 @@ class SpellChecker:
     DICTIONARY = 'dictionary.dic'
 
     GLOB_FLAG_MAP = {
-        "FORECECASE": glob.F,
-        "F": glob.F,
+        ("CASE" if CASE_SUPPORT else "FORCECASE"): (glob.C if CASE_SUPPORT else glob.F),
+        ("C" if CASE_SUPPORT else "F"): (glob.C if CASE_SUPPORT else glob.F),
         "IGNORECASE": glob.I,
         "I": glob.I,
         "RAWCHARS": glob.R,

--- a/pyspelling/__meta__.py
+++ b/pyspelling/__meta__.py
@@ -185,5 +185,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(2, 5, 0, "final")
+__version_info__ = Version(2, 5, 1, "final")
 __version__ = __version_info__._get_canonical()


### PR DESCRIPTION
I will be releasing wcmatch 5.0 which removes an old flag FORCECASE.
It is that useful as it's behavior would force Unix style path logic if
used on a Windows system. For glob, which accesses the filesystem, it
was ignored on Windows anyways. Basically since Unix/Linux behavior is
case sensitive by default, it was a pointless flag to expose in our
environment.

It has been replaced with CASE which actually is more useful and allows
for forcing case sensitivity on a Windows system. Still probably won't
get any use, but we need to account for this change so not break.