### PR TITLE
Add support for wcmatch 6

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.6.0
+
+- **NEW**: Add support for `wcmatch` version `6.0`.
+- **NEW**: `wcmatch` version `6.0` adds a default pattern limit of `1000` to help protect against really large pattern
+  expansions such as `{1..1000000}`. If you wish to control this default, or disable it entirely, you can via the new
+  `glob_pattern_limit` configuration option.
+
 ## 2.5.1
 
 - **FIX**: Add workaround for `wcmatch` version `5.0`.

--- a/docs/src/markdown/configuration.md
+++ b/docs/src/markdown/configuration.md
@@ -172,6 +172,13 @@ matrix:
   - pyspelling/**/*.py
 ```
 
+By default, to protect against really large pattern sets, such as when using brace expansion: `{1..10000000}`, there is
+a pattern limit of `1000` by default. This can be changed by setting `glob_pattern_limit` to some other number. If you
+set it to `0`, it will disable the pattern limits entirely.
+
+!!! new "New 2.6"
+    `glob_pattern_limit` is new in version `2.6` and only works with `wcmatch` version `6.0`.
+
 ### Expect Match
 
 When processing the sources field it is expected to find at least

--- a/pyspelling/__meta__.py
+++ b/pyspelling/__meta__.py
@@ -185,5 +185,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(2, 5, 1, "final")
+__version_info__ = Version(2, 6, 0, "final")
 __version__ = __version_info__._get_canonical()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[wheel]
-universal = 1
-
 [metadata]
 license_file = LICENSE.md

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,57 @@
 """Test text plugin."""
 from . import util
+from wcmatch._wcparse import PatternLimitException
+
+
+class TestGlob(util.PluginTestCase):
+    """Test `glob` behavior."""
+
+    def test_glob_limit(self):
+        """Test `glob` with a custom limit."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: glob
+              default_encoding: utf-8
+              glob_pattern_limit: 10
+              sources:
+              - '{}/**/test-{{1..11}}.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline: null
+            """
+        ).format(self.tempdir)
+        self.mktemp('.glob.yml', config, 'utf-8')
+        with self.assertRaises(PatternLimitException):
+            self.assert_spellcheck('.glob.yml', [])
+
+    def test_glob_no_limit(self):
+        """Test when there is no limit for `glob` expansion patterns."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: glob
+              default_encoding: utf-8
+              glob_pattern_limit: 0
+              sources:
+              - '{}/**/test-{{1..11}}.txt'
+              aspell:
+                lang: en
+              hunspell:
+                d: en_US
+              pipeline: null
+            """
+        ).format(self.tempdir)
+        self.mktemp('.glob.yml', config, 'utf-8')
+
+        bad_words = ['helo', 'begn']
+        good_words = ['yes', 'word']
+        self.mktemp('test-1.txt', '\n'.join(bad_words + good_words), 'utf-8')
+        self.assert_spellcheck('.glob.yml', bad_words)
 
 
 class TestNoPipeline(util.PluginTestCase):


### PR DESCRIPTION
wcmatch 6 will ensure that only unique results get returned. This is
probably the most useful feature that is gained from wcmatch 6.

It also imposes a limit of 1000 patterns in one call. Mainly this
is to protect against pattern expansions, such as with braces:
   {1..10000000000}
1000 should be plenty, but we expose the ability to change this value
or disable it. As this project is mainly used in CI environments where
the maintainer controls this, it is very low risk for someone to
maliciously inject big patterns anyways, but moving forward, we will
support controlling this.

We also expose tilde expansion, which really isn't something that people
should be using in this type of project, but for completeness, it is
exposed.