### PR TITLE
Add support for pre-commit framework

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: pyspelling
+    name: pyspelling
+    entry: pyspelling
+    language: python
+    args: [-S]
+    additional_dependencies: []

--- a/pyspelling/__main__.py
+++ b/pyspelling/__main__.py
@@ -17,7 +17,7 @@ def main():
     group.add_argument('--group', '-g', action='append', help="Specific spelling task groun to run.")
     parser.add_argument('--binary', '-b', action='store', default='', help="Provide path to spell checker's binary.")
     parser.add_argument('--config', '-c', action='store', default='', help="Spelling config.")
-    parser.add_argument('--source', '-S', action='append', help="Specify override file pattern.")
+    parser.add_argument('--source', '-S', nargs='+', help="Specify override file pattern.")
     parser.add_argument(
         '--spellchecker', '-s', action='store', default='', help="Choose between aspell and hunspell"
     )


### PR DESCRIPTION
Pre-commit framework requires a slight modification in the way source files are consumed. It sends all the modified files to the checker tool. This modification allows pyspelling to consume all the paths listed after -S flag instead of requiring to repeat -S flag for each path/pattern. Also, it adds the description of the pre-commit jobs, so now pyspelling may be used in pre-commit pipelines directly from the repo, without additional wrappers.