### PR TITLE
Upgrade wcmatch to 6.0.3

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -48,6 +48,7 @@ backticks
 blockish
 bool
 boolean
+symlink
 builtin
 builtins
 chainable
@@ -65,6 +66,7 @@ facelessuser
 filename
 gforcada
 globbing
+globstar
 iterables
 linter
 lxml

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.6.1
+
+- **FIX**: Upgrade to `wcmatch` 6.0.3 which fixes issues dealing with dot files and globstar (`**`) when dot globbing is
+  not enabled. Also fixes a small logic error with symlink following and globstar. 6.0.3 is now the minimum requirement.
+
 ## 2.6.0
 
 - **NEW**: Add support for `wcmatch` version `6.0`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,7 +60,7 @@ markdown_extensions:
   - markdown.extensions.tables:
   - markdown.extensions.abbr:
   - markdown.extensions.footnotes:
-  - pymdownx.extrarawhtml:
+  - markdown.extensions.md_in_html:
   - pymdownx.superfences:
   - pymdownx.highlight:
       extend_pygments_lang:
@@ -111,4 +111,6 @@ extra:
 plugins:
   - search
   - git-revision-date-localized
+  - minify:
+      minify_html: true
   - mkdocs_pymdownx_material_extras

--- a/pyspelling/__init__.py
+++ b/pyspelling/__init__.py
@@ -6,15 +6,10 @@ from .__meta__ import __version__, __version_info__  # noqa: F401
 from . import flow_control
 from . import filters
 from wcmatch import glob
-import wcmatch
 import codecs
 from collections import namedtuple
 
 __all__ = ("spellcheck",)
-
-CASE_SUPPORT = wcmatch.__version_info__ >= (5, 0)
-NOUNIQUE_SUPPORT = wcmatch.__version_info__ >= (6, 0)
-GLOBTILDE_SUPPORT = wcmatch.__version_info__ >= (6, 0)
 
 
 class Results(namedtuple('Results', ['words', 'context', 'category', 'error'])):
@@ -32,8 +27,8 @@ class SpellChecker:
     DICTIONARY = 'dictionary.dic'
 
     GLOB_FLAG_MAP = {
-        ("CASE" if CASE_SUPPORT else "FORCECASE"): (glob.C if CASE_SUPPORT else glob.F),
-        ("C" if CASE_SUPPORT else "F"): (glob.C if CASE_SUPPORT else glob.F),
+        "CASE": glob.C,
+        "C": glob.C,
         "IGNORECASE": glob.I,
         "I": glob.I,
         "RAWCHARS": glob.R,
@@ -56,10 +51,10 @@ class SpellChecker:
         "X": glob.X,
         "NEGATEALL": glob.A,
         "A": glob.A,
-        "NOUNIQUE": (glob.Q if NOUNIQUE_SUPPORT else 0),
-        "Q": (glob.Q if NOUNIQUE_SUPPORT else 0),
-        "GLOBTILDE": (glob.T if GLOBTILDE_SUPPORT else 0),
-        "T": (glob.T if GLOBTILDE_SUPPORT else 0),
+        "NOUNIQUE": glob.Q,
+        "Q": glob.Q,
+        "GLOBTILDE": glob.T,
+        "T": glob.T,
         # We will accept these, but we already force them on
         "SPLIT": glob.S,
         "S": glob.S,
@@ -185,8 +180,7 @@ class SpellChecker:
         for target in targets:
             # Glob using `S` for patterns wit `|` and `O` to exclude directories.
             kwargs = {"flags": flags | glob.S | glob.O}
-            if NOUNIQUE_SUPPORT:
-                kwargs['limit'] = limit
+            kwargs['limit'] = limit
             for f in glob.iglob(target, **kwargs):
                 found_something = True
                 self.log('', 2)

--- a/pyspelling/__meta__.py
+++ b/pyspelling/__meta__.py
@@ -185,5 +185,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(2, 6, 0, "final")
+__version_info__ = Version(2, 6, 1, "final")
 __version__ = __version_info__._get_canonical()

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,3 +1,4 @@
-mkdocs_pymdownx_material_extras==1.0b5
+mkdocs_pymdownx_material_extras==1.0.1
 mkdocs-git-revision-date-localized-plugin
+mkdocs-minify-plugin
 pyspelling

--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -2,6 +2,6 @@ beautifulsoup4
 soupsieve>=1.8
 markdown
 pyyaml
-wcmatch>=4.0
+wcmatch>=6.0.3
 lxml
 html5lib


### PR DESCRIPTION
Fixes a couple issues with globstar logic. One deals with hidden files
when dotglob is not enabled, and the other deals with symlink following.