### PR TITLE
Change argparse prog from spellcheck -> pyspelling

### DIFF
--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -55,7 +55,7 @@ If you want to manually install it, run `#!bash python setup.py build` and `#!ba
 ## Command Line Usage
 
 ```
-usage: spellcheck [-h] [--version] [--verbose] [--name NAME] [--binary BINARY]
+usage: pyspelling [-h] [--version] [--verbose] [--name NAME] [--binary BINARY]
                   [--config CONFIG] [--spellchecker SPELLCHECKER]
 
 Spell checking tool.

--- a/pyspelling/__main__.py
+++ b/pyspelling/__main__.py
@@ -7,7 +7,7 @@ from pyspelling import spellcheck, __version__
 def main():
     """Main."""
 
-    parser = argparse.ArgumentParser(prog='spellcheck', description='Spell checking tool.')
+    parser = argparse.ArgumentParser(prog='pyspelling', description='Spell checking tool.')
     # Flag arguments
     parser.add_argument('--version', action='version', version=('%(prog)s ' + __version__))
     parser.add_argument('--debug', action='store_true', default=False, help=argparse.SUPPRESS)


### PR DESCRIPTION
The program name is in fact pyspelling, this just updates argparse so
that the `--help` output matches reality. I've also updated the docs in
the website to match.