### PR TITLE
Language option clarification when using Aspell

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -3,6 +3,9 @@
 ## 2.7.0.
 
 - **NEW**: Check for `.pyspelling.yml` or `.pyspelling.yaml` by default.
+- **FIX**: Fix documentation about how to specify languages in Aspell and how to specify languages when compiling custom
+  wordlists. In short, `d` should be used for specifying languages in general, but when using custom wordlists, `lang`
+  should be specified, and it should reference the `.dat` file name..
 - **FIX**: Fix spelling in help output.
 - **FIX**: Raise error in cases where pipeline options are not indented enough and parsed as an additional pipeline
   name.

--- a/docs/src/markdown/configuration.md
+++ b/docs/src/markdown/configuration.md
@@ -31,6 +31,7 @@ matrix:
 - name: Python Source
   aspell:
     lang: en
+    d: en_US
   sources:
   - pyspelling/**/*.py
 ```
@@ -45,6 +46,7 @@ matrix:
   - pyspelling/**/*.py
   aspell:
     lang: en
+    d: en_US
   dictionary:
     wordlists:
     - docs/src/dictionary/en-custom.txt
@@ -252,25 +254,21 @@ matrix:
   pipeline: null
 ```
 
-### Dictionaries and Personal Wordlists
+### Languages
 
-By default, PySpelling sets your main dictionary to `en` for Aspell and `en_US` for Hunspell. If you do not desire an
-American English dictionary, or these dictionaries are not installed in their expected default locations, you will need
-to configure PySpelling so it can find your preferred dictionary. Since dictionary configuring varies for each spell
-checker, the main dictionary is configuration (and virtually any spell checker specific option) is performed via
-[Spell Checker Options](#spell-checker-options).
+Languages in both Aspell and Hunspell are controlled by the `-d` option. In the YAML configuration, we remove any
+leading `-`and just use `d`.
 
-For Aspell, you would use the command line option `--lang` or `-l`, which in the YAML configuration file is `lang` or
-`l` respectively. You can see we are just removing the leading `-` characters.
+For Aspell:
 
 ```yaml
 matrix:
 - name: python
   aspell:
-    lang: en
+    d: en_US
 ```
 
-For Hunspell, you would use the command line option `-d`, which in the YAML configuration file is `d`:
+For Hunspell:
 
 ```yaml
 matrix:
@@ -279,13 +277,65 @@ matrix:
     d: en_US
 ```
 
-While the dictionaries cover a number of commonly used words, they are usually not sufficient. Luckily, both Aspell and
-Hunspell allow for adding custom wordlists. You can have as many wordlists as you like, and they can be included in a
-list under the key `wordlists` which is also found under the key `dictionary`. While Hunspell doesn't directly compile
-the wordlists, Aspell does, and it uses the main dictionary that you have specified to accomplish this.
+Since spell checker options vary between both Aspell and Hunspell, spell checker specific options are handled by under
+special keys named `aspell` and `hunspell`. To learn more, check out [Spell Checker Options](#spell-checker-options).
+
+By default, PySpelling sets your main dictionary to `en` for Aspell and `en_US` for Hunspell. If you do not desire an
+American English dictionary, or these dictionaries are not installed in their expected default locations, you will need
+to configure PySpelling so it can find your preferred dictionary. Since dictionary configuring varies for each spell
+checker, the main dictionary is configuration (and virtually any spell checker specific option) is performed via
+[Spell Checker Options](#spell-checker-options).
+
+### Dictionaries and Personal Wordlists
+
+While provided dictionaries cover a number of commonly used words, you may need to specify additional words that are not
+covered in the default dictionaries. Luckily, both Aspell and Hunspell allow for adding custom wordlists. You can have
+as many wordlists as you like, and they can be included in a list under the key `wordlists` which is also found under
+the key `dictionary`.
 
 All the wordlists are combined into one custom dictionary file whose output name and location is defined via the
 `output` key which is also found under the `dictionary` key.
+
+While Hunspell doesn't directly compile the wordlists, Aspell does, and it uses the `.dat` file for dictionary you are
+using. While you may be specifying a region specific versions of English with `en_US` or `en_GB`, both of these use the
+`en.dat` file. So in Aspell, it is recommended to specify both the `--lang` option (or the alias `-l`) as well as `-d`.
+If `lang` is not specified, the assumed data file will be `en`.
+
+```yaml
+matrix:
+- name: python
+  sources:
+  - pyspelling/**/*.py
+  aspell:
+    lang: en
+    d: en_US
+  dictionary:
+    wordlists:
+    - docs/src/dictionary/en-custom.txt
+    output: build/dictionary/python.dic
+  pipeline:
+  - pyspelling.filters.python:
+      comments: false
+```
+
+Hunspell, on the other hand, does not require an additional `lang` option as custom wordlists are handled differently
+than when under Aspell:
+
+```yaml
+matrix:
+- name: python
+  sources:
+  - pyspelling/**/*.py
+  hunspell:
+    d: en_US
+  dictionary:
+    wordlists:
+    - docs/src/dictionary/en-custom.txt
+    output: build/dictionary/python.dic
+  pipeline:
+  - pyspelling.filters.python:
+      comments: false
+```
 
 Lastly, you can set the encoding to be used during compilation via the `encoding` under `dictionary`. The encoding
 should generally match the encoding of your main dictionary. The default encoding is `utf-8`, and only Aspell uses this
@@ -298,6 +348,7 @@ matrix:
   - pyspelling/**/*.py
   aspell:
     lang: en
+    d: en_US
   dictionary:
     wordlists:
     - docs/src/dictionary/en-custom.txt
@@ -345,6 +396,7 @@ matrix:
   - pyspelling/**/*.py
   aspell:
     lang: en
+    d: en_US
   pipeline:
   - pyspelling.filters.python:
       strings: false

--- a/docs/src/markdown/filters/stylesheets.md
+++ b/docs/src/markdown/filters/stylesheets.md
@@ -20,8 +20,8 @@ matrix:
   - docs/src/scss/*.scss
   aspell:
     lang: en
+    d: en_US
   dictionary:
-    lang: en
     wordlists:
     - docs/src/dictionary/en-custom.txt
     output: build/dictionary/scss.dic

--- a/pyspelling/__init__.py
+++ b/pyspelling/__init__.py
@@ -506,10 +506,9 @@ class Hunspell(SpellChecker):
 
         dictionary_options = task.get('dictionary', {})
         output = os.path.abspath(dictionary_options.get('output', self.dict_bin))
-        lang = dictionary_options.get('lang', 'en_US')
         wordlists = dictionary_options.get('wordlists', [])
-        if lang and wordlists:
-            self.compile_dictionary(lang, dictionary_options.get('wordlists', []), None, output)
+        if wordlists:
+            self.compile_dictionary('', dictionary_options.get('wordlists', []), None, output)
         else:
             output = None
         return output

--- a/tests/filters/test_context.py
+++ b/tests/filters/test_context.py
@@ -16,6 +16,7 @@ class TestContext(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -70,6 +71,7 @@ class TestContextChained(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:

--- a/tests/filters/test_cpp.py
+++ b/tests/filters/test_cpp.py
@@ -16,6 +16,7 @@ class TestCPP(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -78,6 +79,7 @@ class TestCPPGroupedComments(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -162,6 +164,7 @@ class TestCPPStringAllow(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -186,6 +189,7 @@ class TestCPPStringAllow(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -210,6 +214,7 @@ class TestCPPStringAllow(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -234,6 +239,7 @@ class TestCPPStringAllow(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -258,6 +264,7 @@ class TestCPPStringAllow(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -285,6 +292,7 @@ class TestCPPStringAllow(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -312,6 +320,7 @@ class TestCPPStringAllow(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -343,6 +352,7 @@ class TestCPPStrings(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -459,6 +469,7 @@ class TestCPPGeneric(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -516,6 +527,7 @@ class TestCPPChained(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:

--- a/tests/filters/test_html.py
+++ b/tests/filters/test_html.py
@@ -16,6 +16,7 @@ class TestHTML(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -107,6 +108,7 @@ class TestCSSEscapes(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -168,6 +170,7 @@ class TestHtml5AttrNamespace(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -194,6 +197,7 @@ class TestHtml5AttrNamespace(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -221,6 +225,7 @@ class TestHtml5AttrNamespace(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -283,6 +288,7 @@ class TestHtml5EmptySelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -344,6 +350,7 @@ class TestHtml5OnlySelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -371,6 +378,7 @@ class TestHtml5OnlySelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -432,6 +440,7 @@ class TestHtml5NthOfSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -459,6 +468,7 @@ class TestHtml5NthOfSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -483,6 +493,7 @@ class TestHtml5NthOfSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -544,6 +555,7 @@ class TestHtml5NthSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -571,6 +583,7 @@ class TestHtml5NthSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -598,6 +611,7 @@ class TestHtml5NthSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -625,6 +639,7 @@ class TestHtml5NthSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -652,6 +667,7 @@ class TestHtml5NthSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -679,6 +695,7 @@ class TestHtml5NthSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -706,6 +723,7 @@ class TestHtml5NthSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -733,6 +751,7 @@ class TestHtml5NthSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -760,6 +779,7 @@ class TestHtml5NthSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -787,6 +807,7 @@ class TestHtml5NthSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -814,6 +835,7 @@ class TestHtml5NthSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -841,6 +863,7 @@ class TestHtml5NthSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -868,6 +891,7 @@ class TestHtml5NthSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -895,6 +919,7 @@ class TestHtml5NthSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -962,6 +987,7 @@ class TestHtml5AdvancedSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -989,6 +1015,7 @@ class TestHtml5AdvancedSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -1016,6 +1043,7 @@ class TestHtml5AdvancedSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -1044,6 +1072,7 @@ class TestHtml5AdvancedSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -1071,6 +1100,7 @@ class TestHtml5AdvancedSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -1099,6 +1129,7 @@ class TestHtml5AdvancedSelectors(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -1165,6 +1196,7 @@ class TestHtml5AdvancedSelectors2(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -1192,6 +1224,7 @@ class TestHtml5AdvancedSelectors2(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -1219,6 +1252,7 @@ class TestHtml5AdvancedSelectors2(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -1246,6 +1280,7 @@ class TestHtml5AdvancedSelectors2(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -1277,6 +1312,7 @@ class TestHTML5LIB(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -1343,6 +1379,7 @@ class TestXHTML(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -1413,6 +1450,7 @@ class TestHTMLChained(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:

--- a/tests/filters/test_javascript.py
+++ b/tests/filters/test_javascript.py
@@ -16,6 +16,7 @@ class TestJavaScript(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -72,6 +73,7 @@ class TestJavaScriptStrings(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -150,6 +152,7 @@ class TestJavaScriptGroupedComments(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -212,6 +215,7 @@ class TestJavaScriptChained(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:

--- a/tests/filters/test_markdown.py
+++ b/tests/filters/test_markdown.py
@@ -16,6 +16,7 @@ class TestMarkdown(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -71,6 +72,7 @@ class TestMarkdownChained(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:

--- a/tests/filters/test_odf.py
+++ b/tests/filters/test_odf.py
@@ -16,6 +16,7 @@ class TestODFFilter(util.PluginTestCase):
               - 'tests/**/*.odt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -36,6 +37,7 @@ class TestODFFilter(util.PluginTestCase):
               - 'tests/**/*.fodt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -56,6 +58,7 @@ class TestODFFilter(util.PluginTestCase):
               - 'tests/**/*.odp'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -76,6 +79,7 @@ class TestODFFilter(util.PluginTestCase):
               - 'tests/**/*.ods'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -97,6 +101,7 @@ class TestODFFilter(util.PluginTestCase):
               - 'tests/**/*.odt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -118,6 +123,7 @@ class TestODFFilter(util.PluginTestCase):
               - 'tests/**/*.fodt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:

--- a/tests/filters/test_ooxml.py
+++ b/tests/filters/test_ooxml.py
@@ -16,6 +16,7 @@ class TestOOOXMLFilter(util.PluginTestCase):
               - 'tests/**/*.docx'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -36,6 +37,7 @@ class TestOOOXMLFilter(util.PluginTestCase):
               - 'tests/**/*.pptx'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -56,6 +58,7 @@ class TestOOOXMLFilter(util.PluginTestCase):
               - 'tests/**/*.xlsx'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -77,6 +80,7 @@ class TestOOOXMLFilter(util.PluginTestCase):
               - 'tests/**/*.docx'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:

--- a/tests/filters/test_python.py
+++ b/tests/filters/test_python.py
@@ -16,6 +16,7 @@ class TestPython(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -87,6 +88,7 @@ class TestPythonStrings(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -255,6 +257,7 @@ class TestPythonStringAllow(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -277,6 +280,7 @@ class TestPythonStringAllow(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -299,6 +303,7 @@ class TestPythonStringAllow(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -321,6 +326,7 @@ class TestPythonStringAllow(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -343,6 +349,7 @@ class TestPythonStringAllow(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -365,6 +372,7 @@ class TestPythonStringAllow(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -387,6 +395,7 @@ class TestPythonStringAllow(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -413,6 +422,7 @@ class TestPythonChained(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:

--- a/tests/filters/test_stylesheets.py
+++ b/tests/filters/test_stylesheets.py
@@ -16,6 +16,7 @@ class TestStylesheetsCSS(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -61,6 +62,7 @@ class TestStylesheetsSCSS(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -117,6 +119,7 @@ class TestStylesheetsSASS(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -173,6 +176,7 @@ class TestStylesheetsCSSChained(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:

--- a/tests/filters/test_text.py
+++ b/tests/filters/test_text.py
@@ -16,6 +16,7 @@ class TestText(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -64,6 +65,7 @@ class TestTextChained(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:

--- a/tests/filters/test_url.py
+++ b/tests/filters/test_url.py
@@ -16,6 +16,7 @@ class TestURL(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
                 mode: none
               hunspell:
                 d: en_US
@@ -55,6 +56,7 @@ class TestURLChained(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
                 mode: none
               hunspell:
                 d: en_US

--- a/tests/filters/test_xml.py
+++ b/tests/filters/test_xml.py
@@ -16,6 +16,7 @@ class TestXMLNamespaceNoDefault(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -82,6 +83,7 @@ class TestXMLRoot(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:
@@ -147,6 +149,7 @@ class TestXMLNamespace(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:

--- a/tests/flow_control/test_wildcard.py
+++ b/tests/flow_control/test_wildcard.py
@@ -16,6 +16,7 @@ class TestWildcard(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,6 +19,7 @@ class TestGlob(util.PluginTestCase):
               - '{}/**/test-{{1..11}}.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline: null
@@ -41,6 +42,7 @@ class TestGlob(util.PluginTestCase):
               - '{}/**/test-{{1..11}}.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline: null
@@ -69,6 +71,7 @@ class TestNoPipeline(util.PluginTestCase):
               - '{}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline: null
@@ -93,6 +96,7 @@ class TestNoPipeline(util.PluginTestCase):
               - '{temp}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
               pipeline: null
@@ -135,6 +139,7 @@ class TestNameGroup(util.PluginTestCase):
               - '{temp}/**/test1.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
             # Purposely reuse same name
@@ -145,6 +150,7 @@ class TestNameGroup(util.PluginTestCase):
               - '{temp}/**/test2.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
             - name: name3
@@ -155,6 +161,7 @@ class TestNameGroup(util.PluginTestCase):
               - '{temp}/**/test4.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
             """
@@ -189,6 +196,7 @@ class TestNameGroup(util.PluginTestCase):
               - '{temp}/**/test4.txt'
               aspell:
                 lang: en
+                d: en_US
               hunspell:
                 d: en_US
             """
@@ -260,6 +268,7 @@ class TestNameGroup(util.PluginTestCase):
               - '{temp}/**/*.txt'
               aspell:
                 lang: en
+                d: en_US
               pipeline:
               - pyspelling.filters.html:
                 # should be indented more


### PR DESCRIPTION
`d` is the preferred option for specifying languages, but `lang` must
be set to specify the `.dat` file needed when compiling custom
dictionaries from wordlists. This only applies to Aspell.

- Update docs to reflect the above statement
- Update tests and our personal config to properly represent this as
  well as people will most likely look at these cases and use as
  examples.

Fixes #120