### PR TITLE
Fix sample pipeline code

### DIFF
--- a/docs/src/markdown/filters/javascript.md
+++ b/docs/src/markdown/filters/javascript.md
@@ -10,7 +10,7 @@ the text.  The filter can return JSDoc comments, block comment, inline comment, 
 matrix:
 - name: javascript
   pipeline:
-  - pyspelling.filters.javascript
+  - pyspelling.filters.javascript:
       jsdocs: true
       line_comments: false
       block_comments: false


### PR DESCRIPTION
Missing a colon, without it the example can't be copy/pasted.