### PR TITLE
Fix example context filter name

### DIFF
--- a/docs/src/markdown/filters/context.md
+++ b/docs/src/markdown/filters/context.md
@@ -29,7 +29,7 @@ matrix:
   pipeline:
   - pyspelling.filters.python:
       comments: false
-  - pyspelling.filters.context_filter:
+  - pyspelling.filters.context:
       context_visible_first: true
       escapes: '\\[\\`~]'
       delimiters:


### PR DESCRIPTION
`pyspelling.filters.context_filter` doesn't seem to be a valid filter. I tried using it and received `ModuleNotFoundError: No module named 'pyspelling.filters.context_filter'`.  `pyspelling.filters.context` does work, though.