### PR TITLE
Added support for spellchecking markdown sections of Jupyter notebooks

### DIFF
--- a/pyspelling/filters/ipynb.py
+++ b/pyspelling/filters/ipynb.py
@@ -1,0 +1,49 @@
+"""Jupyter Notebook Filter."""
+from .. import filters
+import codecs
+import json
+
+class IpynbFilter(filters.Filter):
+    """Jupyter Notebook Filter."""
+
+    def __init__(self, options, default_encoding='utf-8'):
+        """Initialization."""
+
+        super().__init__(options, default_encoding)
+
+    def get_default_config(self):
+        """Get default configuration."""
+
+        return {}
+
+    def setup(self):
+        """Setup."""
+        # nothing to do here
+
+    def filter(self, source_file, encoding):
+        """Parse Jupyter Notebook."""
+        with codecs.open(source_file, 'r', encoding=encoding) as f:
+            text = f.read()
+            return self.sfilter(text, source_file=source_file, encoding=encoding)
+
+    def sfilter(self, source, source_file="", encoding=""):
+        """Filter."""
+        if source_file == "":
+            source_file = source.context
+        if encoding == "":
+            encoding = source.encoding
+        notebook_data = json.loads(source)
+        markdown_sections = []
+        for cell in notebook_data["cells"]:
+            if cell["cell_type"] == "markdown":
+                cell_string = ""
+                for markdown_line in cell["source"]:
+                    cell_string += markdown_line
+                markdown_sections.append(filters.SourceText(cell_string, source_file, encoding, 'ipynb'))
+        
+        return markdown_sections
+
+def get_plugin():
+    """Return the filter."""
+
+    return IpynbFilter

--- a/tests/filters/test_ipynb.py
+++ b/tests/filters/test_ipynb.py
@@ -1,0 +1,58 @@
+"""Test Jupyter Notebook Plugin."""
+from .. import util
+
+class TestIpynb(util.PluginTestCase):
+    """Test Jupyter Notebook plugin."""
+
+    def setup_fs(self):
+        """Setup file system."""
+
+        config = self.dedent(
+            """
+            matrix:
+            - name: ipynb
+              sources:
+              - '{}/**/*.txt'
+              aspell:
+                lang: en
+                d: en_US
+              hunspell:
+                d: en_US
+              pipeline:
+              - pyspelling.filters.ipynb
+              - pyspelling.filters.markdown
+              - pyspelling.filters.html:
+                  ignores:
+                  - code
+                  - pre
+             """
+        ).format(self.tempdir)
+        self.mktemp('.ipynb.yml', config, 'utf-8')
+
+    def test_ipynb(self):
+        """Test Jupyter Notebook."""
+
+        bad_words = ['helo', 'begn']
+        good_words = ['yes', 'word']
+
+        template = self.dedent(
+            """
+            {{
+              "cells": [
+                {{
+                  "cell_type": "markdown",
+                  "id": "53806b6d",
+                  "metadata": {{}},
+                  "source": [
+                    "{}"
+                  ]
+                }}
+              ]
+            }}
+            """
+        ).format(
+            ' '.join(bad_words + good_words)
+        )
+
+        self.mktemp('test.txt', template, 'utf-8')
+        self.assert_spellcheck('.ipynb.yml', bad_words)


### PR DESCRIPTION
This PR adds support for spell checking the markdown sections of Jupyter notebooks. 

Jupyter notebooks can be relatively easily converted into HTML and evaluated that way, but I believe this approach, checking the notebooks directly, offers a couple advantages:
- Might be slightly less expensive computationally? Probably not a significant move either way though given the current setup still involves some HTML conversion from Markdown.
- Allows for future integration with some of the other filters, particularly the python filter (might require a little bit of rearchitecture) so that different sections can be run through different filters, which should make setting up pipelines simpler than manual extraction (which I believe can be accomplished with a context filter?).
- Should allow for easier configuration in terms of what parts of the file gets processed rather than having to manually filter HTML tags.

Let me know if this is the right approach for this project. If so, I can work on adding any additional feedback and will probably work on some of the possible features outlined above in followup PRs.