### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/pyspelling/__init__.py
+++ b/pyspelling/__init__.py
@@ -11,7 +11,7 @@ from collections import namedtuple
 
 __all__ = ("spellcheck",)
 
-STEP_ERROR = """Pipline step in unexpected format: {}
+STEP_ERROR = """Pipeline step in unexpected format: {}
 
 Each pipeline step should be in the form {{key: options: {{}}}} not {{key: {{}}, key2: {{}}}}
 """
@@ -183,7 +183,7 @@ class SpellChecker:
 
         found_something = False
         for target in targets:
-            # Glob using `S` for patterns wit `|` and `O` to exclude directories.
+            # Glob using `S` for patterns with `|` and `O` to exclude directories.
             kwargs = {"flags": flags | glob.S | glob.O}
             kwargs['limit'] = limit
             for f in glob.iglob(target, **kwargs):

--- a/pyspelling/__main__.py
+++ b/pyspelling/__main__.py
@@ -20,7 +20,7 @@ def main():
     parser.add_argument(
         '--source', '-S',
         action='append',
-        help="Specify override file pattern. Only applicaple when specifying exactly one --name."
+        help="Specify override file pattern. Only applicable when specifying exactly one --name."
     )
     parser.add_argument(
         '--spellchecker', '-s', action='store', default='', help="Choose between aspell and hunspell"

--- a/tests/filters/test_cpp.py
+++ b/tests/filters/test_cpp.py
@@ -45,7 +45,7 @@ class TestCPP(util.PluginTestCase):
                 uint8_t tsdd = 3;
                 // {}
                 // {} \
-                return tsdd;
+                reurn tsdd;
 
                 uint32_t trigraph_test = (CONSTANT_1 ??' ADKASLD) ??' CONSTANT_2; // {}
 
@@ -497,7 +497,7 @@ class TestCPPGeneric(util.PluginTestCase):
                 uint8_t tsdd = 3;
                 // {}
                 // {} \
-                return tsdd;
+                reurn tsdd;
 
                 rtuern ddst;
             }}
@@ -555,7 +555,7 @@ class TestCPPChained(util.PluginTestCase):
                 uint8_t tsdd = 3;
                 // {}
                 // {}
-                return tsdd;
+                reurn tsdd;
             }}
             """
         ).format(

--- a/tests/filters/test_cpp.py
+++ b/tests/filters/test_cpp.py
@@ -45,7 +45,7 @@ class TestCPP(util.PluginTestCase):
                 uint8_t tsdd = 3;
                 // {}
                 // {} \
-                reurn tsdd;
+                return tsdd;
 
                 uint32_t trigraph_test = (CONSTANT_1 ??' ADKASLD) ??' CONSTANT_2; // {}
 
@@ -497,7 +497,7 @@ class TestCPPGeneric(util.PluginTestCase):
                 uint8_t tsdd = 3;
                 // {}
                 // {} \
-                reurn tsdd;
+                return tsdd;
 
                 rtuern ddst;
             }}
@@ -555,7 +555,7 @@ class TestCPPChained(util.PluginTestCase):
                 uint8_t tsdd = 3;
                 // {}
                 // {}
-                reurn tsdd;
+                return tsdd;
             }}
             """
         ).format(


### PR DESCRIPTION
% `pipx run codespell --ignore-words-list=cheking,clen,fo,ned,reurn,smoe,tihs`
% `pipx run codespell --ignore-words-list=cheking,clen,fo,ned,reurn,smoe,tihs --write-changes`
https://pypi.org/project/codespell
