### PR TITLE
Adding configuration for pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,10 @@
+---
+- id: 'pyspelling'
+  name: 'pyspelling'
+  description: 'This hook runs pyspelling'
+  language: 'python'
+  entry: 'pyspelling'
+  pass_filenames: false
+  additional_dependencies:
+    - 'pymdown-extensions'
+...

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -322,7 +322,7 @@ repos:
     hooks:
       - id: 'pyspelling'
         verbose: true
-        pass_filenames: true
+        pass_filenames: false
 ...
 
 Please note that version tags should be preferred over using the `master` branch as revision (`rev`) attribute, as the

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -309,3 +309,21 @@ jobs:
 
 In *this* project, we actually use `tox` to make running our tests locally and in CI easier. If you would like to use
 `tox` as well, you can check out how this project does it by taking a look at the source.
+
+## Usage as pre-commit Hook
+
+`pyspelling` can be used as [`pre-commit`](https://pre-commit.com/) hook. To use it as `pre-commit` hook, please have a
+look at the following example `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: 'https://github.com/facelessuser/pyspelling.git'
+    rev: 'v2.11'
+    hooks:
+      - id: 'pyspelling'
+        verbose: true
+        pass_filenames: true
+...
+
+Please note that version tags should be preferred over using the `master` branch as revision (`rev`) attribute, as the
+`master` branch is considered unstable.

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -316,6 +316,7 @@ PySpelling can be used as a [`pre-commit`](https://pre-commit.com/) hook. To use
 look at the following example `.pre-commit-config.yaml`:
 
 ```yaml
+---
 repos:
   - repo: 'https://github.com/facelessuser/pyspelling.git'
     rev: 'v2.11'
@@ -324,6 +325,7 @@ repos:
         verbose: true
         pass_filenames: false
 ...
+```
 
 Please note that version tags should be preferred over using the `master` branch as revision (`rev`) attribute, as the
 `master` branch is considered unstable.

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -312,7 +312,7 @@ In *this* project, we actually use `tox` to make running our tests locally and i
 
 ## Usage as `pre-commit` Hook
 
-PySpelling can be used as a [`pre-commit`](https://pre-commit.com/) hook. To use it as `pre-commit` hook, please have a
+PySpelling can be used as a [`pre-commit`](https://pre-commit.com/) hook. To use it as a `pre-commit` hook, please have a
 look at the following example `.pre-commit-config.yaml`:
 
 ```yaml

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -312,7 +312,7 @@ In *this* project, we actually use `tox` to make running our tests locally and i
 
 ## Usage as `pre-commit` Hook
 
-PySpelling can be used as [`pre-commit`](https://pre-commit.com/) hook. To use it as `pre-commit` hook, please have a
+PySpelling can be used as a [`pre-commit`](https://pre-commit.com/) hook. To use it as `pre-commit` hook, please have a
 look at the following example `.pre-commit-config.yaml`:
 
 ```yaml

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -310,9 +310,9 @@ jobs:
 In *this* project, we actually use `tox` to make running our tests locally and in CI easier. If you would like to use
 `tox` as well, you can check out how this project does it by taking a look at the source.
 
-## Usage as pre-commit Hook
+## Usage as `pre-commit` Hook
 
-`pyspelling` can be used as [`pre-commit`](https://pre-commit.com/) hook. To use it as `pre-commit` hook, please have a
+PySpelling can be used as [`pre-commit`](https://pre-commit.com/) hook. To use it as `pre-commit` hook, please have a
 look at the following example `.pre-commit-config.yaml`:
 
 ```yaml


### PR DESCRIPTION
I don't know if you'd like to entertain the idea, but I thought I'll give it a try.

With this pull request I am adding a hooks configuration for [`pre-commit`](https://pre-commit.com/), which is a widely used tool for configuring `git hooks`.

I think it makes a lot of sense to run `pyspelling` before committing code, therefore I'd like to contribute it.

Please let me know your thoughts.