### PR TITLE
Fix pre-commit documentation

### DIFF
--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -319,7 +319,7 @@ look at the following example `.pre-commit-config.yaml`:
 ---
 repos:
   - repo: 'https://github.com/facelessuser/pyspelling.git'
-    rev: 'v2.11'
+    rev: '2.11'
     hooks:
       - id: 'pyspelling'
         verbose: true


### PR DESCRIPTION
Two minor things.

The name of the revision has to be exactly the same as the git tag, I think. Which (at least until 2.10) is without the "v"?

`pass_filenames` is already part of [.pre-commit-hooks.yaml](https://github.com/facelessuser/pyspelling/blob/63e4654f0be643ca0f1676227db24bb7f88dee29/.pre-commit-hooks.yaml#L7) so I guess this is obsolete here?